### PR TITLE
chore: add tooling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,50 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var ts = require('gulp-typescript');
+var del = require('del');
+var webpack = require('webpack');
+
+gulp.task('clean', function (cb) {
+  del('dist/', cb);
+});
+
+gulp.task('es5', function () {
+  var tsProject = ts.createProject('tsconfig.json', {
+    module: 'commonjs',
+    target: 'es5'
+  });
+
+  var tsResult = gulp.src(['typings/tsd.d.ts', 'src/**/*.ts'])
+    .pipe(ts(tsProject));
+
+  return tsResult.js.pipe(gulp.dest('dist/cjs'));
+});
+
+gulp.task('es6', function () {
+  var tsProject = ts.createProject('tsconfig.json');
+
+  var tsResult = gulp.src(['typings/tsd.d.ts', 'src/**/*.ts'])
+    .pipe(ts(tsProject));
+
+  return tsResult.js.pipe(gulp.dest('dist/es6'));
+});
+
+gulp.task('umd', ['es5', 'es6'], function (cb) {
+  webpack({
+    entry: './dist/cjs/core.js',
+    output: {
+      filename: 'dist/global/ng-bootstrap.js',
+      libraryTarget: 'umd'
+    },
+    externals: {
+      'angular2/angular2': 'angular2/angular2'
+    }
+  }, function (err, stats) {
+    if (err) throw new gutil.PluginError('webpack', err);
+    gutil.log("[webpack]", stats.toString());
+    cb();
+  })
+});
+
+gulp.task('build', ['clean', 'umd']);
+gulp.task('default', ['build']);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ui-boostrap2-core",
   "version": "1.0.0",
   "description": "ui-bootstrap core components for angular2",
-  "main": "dist/core.js",
+  "main": "dist/cjs/core.js",
   "scripts": {
     "setup": "node misc/validate-commit.install.js && tsd reinstall",
     "build": "rm -rf dist/ && tsc",
@@ -27,5 +27,13 @@
     "devDependencies": {
       "typescript": "github:microsoft/typescript@v1.6.2"
     }
+  },
+  "devDependencies": {
+    "del": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-typescript": "^2.9.0",
+    "gulp-util": "^3.0.6",
+    "typescript": "^1.6.2",
+    "webpack": "^1.12.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES5",
+    "target": "ES6",
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "outDir": "dist"
+    "experimentalDecorators": true
   },
   "files": [
+    "typings/tsd.d.ts",
     "src/core.ts",
     "src/components/accordion.ts",
     "src/services/multiMap.ts",


### PR DESCRIPTION
The never coming PR.

Basic workflow based on simple Gulp. It is able to generate ES6, ES5 and a final UMD build (thanks to webpack).

I deleted all the `reference` entries on the files. They are not needed since I feed it directly to `tsc`.

I can see the cases where an editor requires that `reference` to make proper highlight. I guess there should be tools for not requiring that. Webstorm directly reads from typings to offer proper highlighting.

If you run it now, stackedMap won't be transformed, it is broken, will fix it.

On the other hand, the ES6 gives a bunch of errors, nothing of our business and it should be fixed in .38.

I will continue working on the tooling time to time, to organize it better, move strings out and give it more features towards a future release, but for now it works perfectly to generate an UMD and use it directly on a plunker.

Ah, you can check a demo plunker with the end result:  http://plnkr.co/edit/UvD9er6I92aD3UfZqb5W?p=preview