### PR TITLE
chore(stackedMap): export interface

### DIFF
--- a/src/services/stackedMap.ts
+++ b/src/services/stackedMap.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../typings/tsd.d.ts" />
 
-interface keyVal {
+export interface keyVal {
   key: Object;
   value: Object;
 }


### PR DESCRIPTION
If I am not mistaken, if you export something like a `class` (StackedMap in this case) and you use an interface that is not exported, typescript will cry. To fix that, you need to export the interface as well.