### PR TITLE
chore: clean tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,10 @@
     "experimentalDecorators": true
   },
   "files": [
-    "node_modules/typescript/lib/lib.es6.d.ts",
     "typings/tsd.d.ts",
     "src/core.ts",
     "src/components/accordion.ts",
     "src/services/multiMap.ts",
     "src/services/stackedMap.ts"
-  ],
-  "exclude": [
-    "node_modules"
   ]
 }


### PR DESCRIPTION
Those things doesn't add value.

No need of exclude because that gets override by files and I am not even using that for compiling, just for IDE / Editors sake.

Also remove that extra d.ts, that will be fed to gulp directly.