### PR TITLE
chore: tune tsconfig to prevent compilation on save

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "typings/tsd.d.ts",
     "src/core.ts",
     "src/components/dropdown.ts"
-  ]
+  ],
+  "compileOnSave": false
 }


### PR DESCRIPTION
This is only a fix for Atom, but since Wes uses Atom, it is best to have it.

For the rest, this prevents `atom-typescript` to compile a `.ts` every time you save a file, you don't need that for this project.