### PR TITLE
feat(accordion): create working accordion

### DIFF
--- a/src/components/accordion.ts
+++ b/src/components/accordion.ts
@@ -1,0 +1,71 @@
+import {Component, View, OnDestroy} from 'angular2/angular2';
+
+@Component({selector: 'ngb-accordion, [ngb-accordion]', properties: ['onlyOneOpen: closeOthers']})
+@View({template: `<ng-content></ng-content>`})
+export class NgbAccordion {
+  private onlyOneOpen: boolean;
+  private groups: Array<NgbAccordionGroup> = [];
+
+  addGroup(group: NgbAccordionGroup): void { this.groups.push(group); }
+
+  closeOthers(openGroup): void {
+    if (!this.onlyOneOpen) {
+      return;
+    }
+
+    this.groups.forEach((group: NgbAccordionGroup) => {
+      if (group !== openGroup) {
+        group.isOpen = false;
+      }
+    });
+  }
+
+  removeGroup(group: NgbAccordionGroup): void {
+    const index = this.groups.indexOf(group);
+    if (index !== -1) {
+      this.groups.splice(index, 1);
+    }
+  }
+}
+
+@Component({selector: 'ngb-accordion-group, [ngb-accordion-group]', properties: ['heading', 'isOpen', 'isDisabled']})
+@View({
+  template: `
+    <div class="panel panel-default" [class.panel-open]="isOpen">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a href tabindex="0"><span [class.text-muted]="isDisabled" (click)="toggleOpen($event)">{{heading}}</span></a>
+        </h4>
+      </div>
+      <div class="panel-collapse" [hidden]="!isOpen">
+        <div class="panel-body">
+    	    <ng-content></ng-content>
+  	    </div>
+      </div>
+    </div>
+  `
+})
+export class NgbAccordionGroup implements OnDestroy {
+  private isDisabled: boolean;
+  private _isOpen: boolean = false;
+
+  constructor(private accordion: NgbAccordion) { this.accordion.addGroup(this); }
+
+  toggleOpen(event) {
+    event.preventDefault();
+    if (!this.isDisabled) {
+      this.isOpen = !this.isOpen;
+    }
+  }
+
+  onDestroy(): void { this.accordion.removeGroup(this); }
+
+  public get isOpen(): boolean { return this._isOpen; }
+
+  public set isOpen(value: boolean) {
+    this._isOpen = value;
+    if (value) {
+      this.accordion.closeOthers(this);
+    }
+  }
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,1 +1,2 @@
+export {NgbAccordion, NgbAccordionGroup} from './components/accordion';
 export {NgbDropdown, NgbDropdownMenu} from './components/dropdown';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   "files": [
     "typings/tsd.d.ts",
     "src/core.ts",
+    "src/components/accordion.ts",
     "src/components/dropdown.ts"
   ]
 }


### PR DESCRIPTION
There is a few things to notice, but I will add comments on the code directly.

Back in uibs@BS3 we used to toggle by clicking on the entire header, in BS4 it only toggles if you click on the text and not outside of it. Makes sense for me because the new accordion style (way uglier) doesn't make clear where is the separation between header and content.

[Plunker](http://plnkr.co/edit/XuH7mXBycODO7KYgNSbH?p=preview)