### PR TITLE
feat(buttons): create button directives

### DIFF
--- a/src/components/buttons.ts
+++ b/src/components/buttons.ts
@@ -1,0 +1,38 @@
+import {Directive, View} from 'angular2/angular2';
+
+@Directive({
+  selector: '[ngb-button-checkbox]',
+  properties: [
+    'name: ngb-name', 'checked: ngb-checked', 'class: ngb-class'
+  ],
+  host: {
+    '[class]': 'class',
+    '[class.active]': 'checked'
+  }
+})
+@View({
+  template: `
+    <input type="checkbox" [checked]="checked" [name]="name" autocomplete="off">
+    <ng-content></ng-content>`
+})
+export class NgbButtonCheckbox {
+  private checked: boolean;
+}
+
+@Directive({
+  selector: '[ngb-button-radio]',
+  properties: [
+    'name: ngb-name', 'checked: ngb-checked', 'class: ngb-class'
+  ],
+  host: {
+    '[class]': 'class',
+    '[class.active]': 'checked'
+  }
+})
+@View({
+  template: `<input type="radio" [checked]="checked" [name]="name" autocomplete="off">
+    <ng-content></ng-content>`
+})
+export class NgbButtonRadio {
+  private checked: boolean;
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,1 +1,2 @@
+export {NgBButtonCheckbox, NgbButtonRadio} from './components/buttons';
 export {NgbDropdown, NgbDropdownMenu} from './components/dropdown';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   "files": [
     "typings/tsd.d.ts",
     "src/core.ts",
+    "src/components/buttons.ts",
     "src/components/dropdown.ts"
   ],
   "compileOnSave": false


### PR DESCRIPTION
- Create `NgbButtonCheckbox` and `NgbButtonRadio` directives

Working Plunker [here](http://plnkr.co/edit/xAOz2VWFvkG0dr2QVS5d?p=preview)

This is not quite there yet - the template needs to be applied for accessibility reasons, but unfortunately using a `Component` decorator causes click eventing to get thrown off.

This addresses #14.