### PR TITLE
chore: fix umd for es5

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,8 +29,11 @@ gulp.task('umd', ['es5', 'es6'], function(cb) {
   webpack(
       {
         entry: './dist/cjs/core.js',
-        output: {filename: 'dist/global/ng-bootstrap.js', libraryTarget: 'umd'},
-        externals: {'angular2/angular2': 'angular2/angular2'}
+        output: {filename: 'dist/global/ng-bootstrap.js', library: 'ngb', libraryTarget: 'umd'},
+        externals: {
+          'angular2/angular2':
+              {root: 'ng', commonjs: 'angular2/angular2', commonjs2: 'angular2/angular2', amd: 'angular2/angular2'}
+        }
       },
       function(err, stats) {
         if (err) throw new gutil.PluginError('webpack', err);


### PR DESCRIPTION
This is what I meant on the talk.

Now our UMD build fails for plain ES5 users and this fixes it.

This tooling could potentially go away with other changes based on how we would need to do testing.

Still, for the time being, helps testing the library on a plunker for ES5 users.