### PR TITLE
chore: testing tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules/
 /typings/
 /dist/
+/temp/
 npm-debug.log
 .sw*
 .idea

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -1,0 +1,64 @@
+// Tun on full stack traces in errors to help debugging
+Error.stackTraceLimit=Infinity;
+
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+
+// // Cancel Karma's synchronous start,
+// // we will call `__karma__.start()` later, once all the specs are loaded.
+__karma__.loaded = function() {};
+
+
+System.config({
+  packages: {
+    'base/temp/components': {
+      defaultExtension: false,
+      format: 'register',
+      map: Object.keys(window.__karma__.files).
+            filter(onlyAppFiles).
+            reduce(function createPathRecords(pathsMapping, appPath) {
+              // creates local module name mapping to global path with karma's fingerprint in path, e.g.:
+              // './hero.service': '/base/temp/components/hero.service.js?f4523daf879cfb7310ef6242682ccf10b2041b3e'
+              var moduleName = appPath.replace(/^\/base\/temp\/components\//, './').replace(/\.js$/, '');
+              pathsMapping[moduleName] = appPath + '?' + window.__karma__.files[appPath]
+              return pathsMapping;
+            }, {})
+
+      }
+    }
+});
+
+System.import('angular2/src/core/dom/browser_adapter').then(function(browser_adapter) {
+  browser_adapter.BrowserDomAdapter.makeCurrent();
+}).then(function() {
+  return Promise.all(
+    Object.keys(window.__karma__.files) // All files served by Karma.
+    .filter(onlySpecFiles)
+    // .map(filePath2moduleName)        // Normalize paths to module names.
+    .map(function(moduleName) {
+      // loads all spec files via their global module names (e.g. 'base/temp/test/hero.service_test')
+      return System.import(moduleName);
+    }));
+})
+.then(function() {
+  __karma__.start();
+}, function(error) {
+  __karma__.error(error.stack || error);
+});
+
+
+function filePath2moduleName(filePath) {
+  return filePath.
+           replace(/^\//, '').              // remove / prefix
+           replace(/\.\w+$/, '');           // remove suffix
+}
+
+
+function onlyAppFiles(filePath) {
+  return /^\/base\/temp\/components\/.*\.js$/.test(filePath)
+}
+
+
+function onlySpecFiles(path) {
+  return /_test\.js$/.test(path);
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,31 @@
+module.exports = function(config) {
+  config.set({
+
+    basePath: '',
+
+    frameworks: ['jasmine'],
+
+    files: [
+      // paths loaded by Karma
+      {pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: true},
+      {pattern: 'node_modules/angular2/bundles/angular2.js', included: true, watched: true},
+      {pattern: 'node_modules/angular2/bundles/testing.js', included: true, watched: true},
+      {pattern: 'karma-test-shim.js', included: true, watched: true},
+
+      // paths loaded via module imports
+      {pattern: 'temp/**/*.js', included: false, watched: true},
+
+      // paths to support debugging with source maps in dev tools
+      {pattern: 'src/**/*.ts', included: false, watched: false},
+      {pattern: 'temp/**/*.js.map', included: false, watched: false}
+    ],
+
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false
+  })
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "main": "dist/cjs/core.js",
   "scripts": {
     "setup": "node misc/validate-commit.install.js",
-    "build": "rm -rf dist && tsc && gulp build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "rm -rf dist && tsc src/core.ts --outDir dist/cjs --target ES5 --module commonjs -d --experimentalDecorators --emitDecoratorMetadata && gulp build",
+    "watch": "tsc --watch",
+    "build_tests": "rm -rf temp && tsc",
+    "test": "karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +26,12 @@
     "gulp": "^3.9.0",
     "gulp-clang-format": "^1.0.21",
     "gulp-util": "^3.0.6",
+    "jasmine": "^2.3.2",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.13.14",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-jasmine": "^0.3.6",
+    "systemjs": "^0.19.5",
     "typescript": "^1.6.2",
     "webpack": "^1.12.2"
   }

--- a/src/test/sanity_test.ts
+++ b/src/test/sanity_test.ts
@@ -1,0 +1,9 @@
+describe('universal truths', () => {
+  it('should do math', () => {
+    expect(1 + 1).toEqual(2);
+
+    expect(5).toBeGreaterThan(4);
+  });
+
+  xit('should skip this', () => { expect(4).toEqual(40); });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,20 @@
   "compilerOptions": {
     "target": "ES5",
     "module": "commonjs",
+    "sourceMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "declaration": true,
-    "outDir": "dist/cjs"
+    "outDir": "temp/"
   },
   "files": [
     "src/core.ts",
     "src/components/accordion.ts",
     "src/components/dropdown.ts",
-    "src/components/rating.ts"
+    "src/components/rating.ts",
+    "src/test/sanity_test.ts"
   ],
-  "compileOnSave": false
+  "compileOnSave": false,
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Alrighty, let me explain how this work.

Since testing as today is only possible using systemjs, I needed to extend the tooling to support that.

We needed two tsconfig, but we could only put one. Since that for editor supports we will need to list the files on the tsconfig, I put the testing tsconfig as the main one and "embed" the build one in the package.json.

So now, we have a `test` folder inside `src` where we can put our tests. (the convention is `foo_test.ts`).

As with source files, we need to add test files to `tsconfig.json`.

To make this work, you can run `npm run watch` in one tab and in another tab `npm test`.

There is no way yet to run the tests once nor generate a build after tests are green, but we don't care about atm. The important bit is that we can write tests now.

If you think that I should change some convention, feel free (but this can change in the future too).