### PR TITLE
chore: don't list individual files in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,6 @@
     "experimentalDecorators": true,
     "outDir": "temp/"
   },
-  "files": [
-    "src/core.ts",
-    "src/components/accordion.ts",
-    "src/components/dropdown.ts",
-    "src/components/rating.ts",
-    "src/test/rating.test.ts"
-  ],
   "compileOnSave": false,
   "exclude": [
     "node_modules"


### PR DESCRIPTION
We don't want to list each and individual file in tsconfig.json

`"moduleResolution": "node"` instructs TS to look for typings in node_modules folders so it can easily find angular2 typings.