### PR TITLE
chore(tooling): move everything to gulp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - npm install --quiet -g gulp
 
-script: npm run test:ci
-
+script: gulp
 sudo: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,27 @@
 var gulp = require('gulp');
+var ts = require('gulp-typescript');
 var gutil = require('gulp-util');
+var sourcemaps = require('gulp-sourcemaps');
+var ddescribeIit = require('gulp-ddescribe-iit');
+var karmaServer = require('karma').Server;
 var webpack = require('webpack');
-var gulpFormat = require('gulp-clang-format');
+var del = require('del');
+var merge = require('merge2');
 var clangFormat = require('clang-format');
+var gulpFormat = require('gulp-clang-format');
+var runSequence = require('run-sequence');
+
+// Transpiling & Building
+
+var buildProject = ts.createProject('tsconfig.json', {declaration: true});
+
+gulp.task('clean:build', function() { return del('dist/'); });
+
+gulp.task('cjs', function() {
+  var tsResult = gulp.src(['src/**/*.ts', '!src/**/*.spec.ts']).pipe(ts(buildProject));
+
+  return merge([tsResult.dts.pipe(gulp.dest('dist/cjs')), tsResult.js.pipe(gulp.dest('dist/cjs'))]);
+});
 
 gulp.task('umd', function(cb) {
   webpack(
@@ -18,8 +37,39 @@ gulp.task('umd', function(cb) {
         if (err) throw new gutil.PluginError('webpack', err);
         gutil.log("[webpack]", stats.toString());
         cb();
-      })
+      });
 });
+
+// Testing
+
+var testProject = ts.createProject('tsconfig.json');
+
+gulp.task('build-tests', function() {
+  var tsResult = gulp.src('src/**/*.ts').pipe(sourcemaps.init()).pipe(ts(testProject));
+
+  return tsResult.js.pipe(sourcemaps.write('.')).pipe(gulp.dest('temp'));
+});
+
+gulp.task('ddescribe-iit', function() {
+  return gulp.src('src/**/*.spec.ts').pipe(ddescribeIit({allowDisabledTests: false}));
+});
+
+gulp.task('test', function(done) {
+  var travis = process.env.TRAVIS;
+
+  var config = {configFile: __dirname + '/karma.conf.js', singleRun: true, autoWatch: false};
+
+  if (travis) {
+    config['reporters'] = ['dots'];
+    config['browsers'] = ['Firefox'];
+  }
+
+  new karmaServer(config, done).start();
+});
+
+gulp.task('watch', ['build-tests'], function() { gulp.watch('src/**/*.ts', ['build-tests']); });
+
+// Formatting
 
 gulp.task('check-format', function() {
   return doCheckFormat().on(
@@ -34,11 +84,15 @@ gulp.task('enforce-format', function() {
   });
 });
 
-gulp.task('build', ['umd', 'check-format']);
-gulp.task('default', ['build']);
-
-// formatting
 function doCheckFormat() {
-  return gulp.src(['gulpfile.js', 'karma-test-shim.js', 'src/**/*.ts'])
+  return gulp.src(['gulpfile.js', 'tasks/**/*.js', 'karma-test-shim.js', 'src/**/*.ts'])
       .pipe(gulpFormat.checkFormat('file', clangFormat));
 }
+
+// Public Tasks
+
+gulp.task('build', function(done) {
+  runSequence('enforce-format', 'ddescribe-iit', 'build-tests', 'test', 'clean:build', 'cjs', 'umd', done);
+});
+
+gulp.task('default', function(done) { runSequence('enforce-format', 'ddescribe-iit', 'build-tests', 'test', done); });

--- a/package.json
+++ b/package.json
@@ -5,12 +5,8 @@
   "author": "https://github.com/ng-bootstrap/core/graphs/contributors",
   "main": "dist/cjs/core.js",
   "scripts": {
-    "setup": "node misc/validate-commit.install.js",
-    "build": "rm -rf dist && tsc src/core.ts --outDir dist/cjs --target ES5 --module commonjs -d --experimentalDecorators --emitDecoratorMetadata && gulp build",
-    "watch": "tsc --watch",
-    "build_tests": "rm -rf temp && tsc",
-    "test": "karma start karma.conf.js",
-    "test:ci": "tsc && karma start --single-run --reporters dots --browsers Firefox"
+    "install": "node misc/validate-commit.install.js",
+    "test": "karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -24,9 +20,13 @@
   "devDependencies": {
     "angular2": "^2.0.0-alpha.45",
     "clang-format": "^1.0.29",
+    "del": "^2.0.2",
     "es6-shim": "^0.33.8",
     "gulp": "^3.9.0",
     "gulp-clang-format": "^1.0.21",
+    "gulp-ddescribe-iit": "^1.3.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-typescript": "^2.9.2",
     "gulp-util": "^3.0.6",
     "jasmine": "^2.3.2",
     "jasmine-core": "^2.3.4",
@@ -34,6 +34,8 @@
     "karma-chrome-launcher": "^0.2.1",
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
+    "merge2": "^0.3.6",
+    "run-sequence": "^1.1.4",
     "systemjs": "^0.19.5",
     "typescript": "^1.6.2",
     "webpack": "^1.12.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,8 @@
   "compilerOptions": {
     "target": "ES5",
     "module": "commonjs",
-    "sourceMap": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "outDir": "temp/"
+    "experimentalDecorators": true
   },
   "compileOnSave": false,
   "exclude": [


### PR DESCRIPTION
Not the simple PR you want to see.

This is a workflow made with the right base to make it group up when we need some extra tasks.

I split it in 3 separate categories. The important bits are:

Instead of having a insanely big task like we did on ui-bootstrap that would do everything, I split it in two tasks:

* `gulp` - This is the task you want to run before commit, to make sure that everything is correct (formatting and tests).
* `gulp build` - Does all the previous things, but also builds the project.

For testing + watch, you need two tabs (no way to simplify that I think):

One with `gulp watch` and the other, `gulp test` or `karma start` or `npm test`. I left the `npm test` for convenience.

Travis will run the  `gulp` one. It doesn't need to build anything, that only adds time.

Cleaned the package.json, and moved the git hook to a `install` hook. That is a better way of managing it.

After this gets merged, I will update the docs to explain how to work with this tooling.
