### PR TITLE
feat(progressbar): add initial progressbar

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -2,13 +2,23 @@ import {NgbAccordion, NgbAccordionPanel} from './accordion/accordion';
 import {NgbCollapse} from './collapse/collapse';
 import {NgbDropdown, NgbDropdownToggle} from './dropdown/dropdown';
 import {NgbPagination} from './pagination/pagination';
+import {NgbProgressbar} from './progressbar/progressbar';
 import {NgbRating} from './rating/rating';
 
 export {NgbAccordion, NgbAccordionPanel} from './accordion/accordion';
 export {NgbCollapse} from './collapse/collapse';
 export {NgbDropdown, NgbDropdownToggle} from './dropdown/dropdown';
 export {NgbPagination} from './pagination/pagination';
+export {NgbProgressbar} from './progressbar/progressbar';
 export {NgbRating} from './rating/rating';
 
-export const NGB_DIRECTIVES =
-    [NgbAccordion, NgbAccordionPanel, NgbCollapse, NgbDropdown, NgbDropdownToggle, NgbPagination, NgbRating];
+export const NGB_DIRECTIVES = [
+  NgbAccordion,
+  NgbAccordionPanel,
+  NgbCollapse,
+  NgbDropdown,
+  NgbDropdownToggle,
+  NgbPagination,
+  NgbProgressbar,
+  NgbRating
+];

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -1,0 +1,116 @@
+import {iit, it, ddescribe, describe, expect, injectAsync, TestComponentBuilder} from 'angular2/testing';
+
+import {Component} from 'angular2/angular2';
+
+import {NgbProgressbar} from "./progressbar";
+
+function getBarWidth(nativeEl): string {
+  return nativeEl.querySelector('.progress-bar').style.width;
+}
+
+function getProgressbar(nativeEl: Element): Element {
+  return nativeEl.querySelector('progress');
+}
+
+describe('ng-progressbar', () => {
+
+  describe('business logic', () => {
+    let progressCmp: NgbProgressbar;
+
+    beforeEach(() => { progressCmp = new NgbProgressbar(); });
+
+    it('should calculate the percentage (default max size)', () => {
+      progressCmp.value = 50;
+      expect(progressCmp.calculatePercentage()).toBe(50);
+
+      progressCmp.value = 25;
+      expect(progressCmp.calculatePercentage()).toBe(25);
+    });
+
+    it('should calculate the percentage (custom max size)', () => {
+      progressCmp.max = 150;
+
+      progressCmp.value = 75;
+      expect(progressCmp.calculatePercentage()).toBe(50);
+
+      progressCmp.value = 30;
+      expect(progressCmp.calculatePercentage()).toBe(20);
+    });
+  });
+
+  describe('UI logic', () => {
+    it('accepts a value and respond to value changes', injectAsync([TestComponentBuilder], (tcb) => {
+         const html = '<ngb-progressbar [value]="value"></ngb-progressbar>';
+
+         return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.detectChanges();
+
+           expect(getBarWidth(fixture.debugElement.nativeElement)).toBe('10%');
+
+           fixture.debugElement.componentInstance.value = 30;
+           fixture.detectChanges();
+           expect(getBarWidth(fixture.debugElement.nativeElement)).toBe('30%');
+         });
+       }));
+
+    it('accepts a max value and respond to max changes', injectAsync([TestComponentBuilder], (tcb) => {
+         const html = '<ngb-progressbar [value]="value" [max]="max"></ngb-progressbar>';
+
+         return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.detectChanges();
+
+           expect(getBarWidth(fixture.debugElement.nativeElement)).toBe('20%');
+
+           fixture.debugElement.componentInstance.max = 200;
+           fixture.detectChanges();
+           expect(getBarWidth(fixture.debugElement.nativeElement)).toBe('5%');
+         });
+       }));
+
+    it('accepts a custom type', injectAsync([TestComponentBuilder], (tcb) => {
+         const html = '<ngb-progressbar [value]="value" [type]="type"></ngb-progressbar>';
+
+         return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.detectChanges();
+
+           expect(getProgressbar(fixture.debugElement.nativeElement)).toHaveCssClass('progress-warning');
+
+           fixture.debugElement.componentInstance.type = 'info';
+           fixture.detectChanges();
+           expect(getProgressbar(fixture.debugElement.nativeElement)).toHaveCssClass('progress-info');
+         });
+       }));
+
+    it('accepts striped as boolean attr', injectAsync([TestComponentBuilder], (tcb) => {
+         const html = '<ngb-progressbar [value]="value" striped></ngb-progressbar>';
+
+         return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.detectChanges();
+
+           expect(getProgressbar(fixture.debugElement.nativeElement)).toHaveCssClass('progress-striped');
+         });
+       }));
+
+    it('accepts striped as normal attr', injectAsync([TestComponentBuilder], (tcb) => {
+         const html = '<ngb-progressbar [value]="value" [striped]="striped"></ngb-progressbar>';
+
+         return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.detectChanges();
+
+           expect(getProgressbar(fixture.debugElement.nativeElement)).toHaveCssClass('progress-striped');
+
+           fixture.debugElement.componentInstance.striped = false;
+           fixture.detectChanges();
+           expect(getProgressbar(fixture.debugElement.nativeElement)).not.toHaveCssClass('progress-striped');
+         });
+       }));
+  });
+});
+
+@Component({selector: 'test-cmp', directives: [NgbProgressbar], template: ''})
+class TestComponent {
+  value = 10;
+  max = 50;
+  striped = true;
+  type = 'warning';
+}

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -1,0 +1,34 @@
+import {Component, Input} from 'angular2/angular2';
+
+@Component({
+  selector: 'ngb-progressbar',
+  template: `
+    <progress class="progress {{striped && 'progress-striped'}} {{type && 'progress-' + type}}" [value]="value" [max]="max">
+      <div class="progress">
+        <span class="progress-bar" [style.width.%]="calculatePercentage()"><ng-content></ng-content></span>
+      </div>
+    </progress>
+  `
+})
+export class NgbProgressbar {
+  private _striped: boolean;
+
+  @Input() max = 100;
+
+  @Input()
+  set striped(value: boolean | string) {
+    if (value === '') {  // boolean usage
+      value = true;
+    }
+
+    this._striped = !!value;
+  }
+
+  get striped(): boolean | string { return this._striped; }
+
+  @Input() type: string;
+
+  @Input() value: number;
+
+  calculatePercentage() { return 100 * this.value / this.max; }
+}


### PR DESCRIPTION
It is the barebones just yet, but there is something important I want to discuss in here and I am waiting for the tooling to make the development a bit easier.

The problem I have in here is that we use it like:

```
<ngb-progressbar class="progress-striped" value="22"></ngb-progressbar>
```

The problem is that it was going to generate a whole progressbar inside, copy the `progress-striped` class and apply it inside it. Works good but then we will have two elements carrying the same class, and that can backfire pretty easily.

I hacked it a bit so I delete the classes on the parent but I am not loving the approach.

Check this [plunker](http://plnkr.co/edit/9Vts7W6wNtWSjRRhhazX?p=preview).

Thoughts?