### PR TITLE
chore(dropdown): switch menu to directive

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from 'angular2/angular2';
+import {Component, Directive, Input} from 'angular2/angular2';
 
 @Component({
   selector: 'ngb-dropdown',
@@ -10,6 +10,6 @@ export class NgbDropdown {
   @Input() private open: boolean;
 }
 
-@Component({selector: 'ngb-dropdown-menu', host: {'class': 'dropdown-menu'}, template: `<ng-content></ng-content>`})
+@Directive({selector: 'ngb-dropdown-menu', host: {'class': 'dropdown-menu'}})
 export class NgbDropdownMenu {
 }


### PR DESCRIPTION
A `<ng-content>` template makes sense if you have something else on the template. If you remove the template entirely, the inner content will appear nonetheless.

Not sure about the chore thing, but I think that the first changelog won't be autogenerated (lot of experimentation that would result in a weird changelog.

[Plunker](http://plnkr.co/edit/0GZqyybzjOuc88Gw31p3?p=preview)