### PR TITLE
feat(collapse): add initial collapse

### DIFF
--- a/src/collapse/collapse.spec.ts
+++ b/src/collapse/collapse.spec.ts
@@ -1,0 +1,118 @@
+import {
+  iit,
+  it,
+  ddescribe,
+  describe,
+  expect,
+  inject,
+  injectAsync,
+  TestComponentBuilder,
+  beforeEachProviders
+} from 'angular2/testing';
+
+import {Component} from 'angular2/angular2';
+
+import {NgbCollapse} from './collapse';
+
+function getCollapsibleContent(element: Element): Element {
+  return element.querySelector('.collapse');
+}
+
+function getButton(element) {
+  return element.querySelector('button');
+}
+
+
+function hasClass(element: Element, str: string): Boolean {
+  return new RegExp(`(^|\\s)${str}(\\s|$)`).test(element.className);
+}
+
+function hasStyle(element: Element, str: string): Boolean {
+  return new RegExp(`(^|\\s)${str}(\\s|$)`).test(element.getAttribute('style'));
+}
+
+describe('ngb-collapse', () => {
+  let html: string;
+
+  beforeEach(() => {
+    html = `
+      <button type="button" (click)="collapsed = !collapsed">Toggle collapse</button>
+      <div [ngb-collapse]="collapsed">
+        <div class="card">
+          <div class="card-block">
+            Some content
+          </div>
+        </div>
+      </div>
+    `;
+  });
+
+  it('should have content open and aria-expanded true', injectAsync([TestComponentBuilder], (tcb) => {
+       return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         fixture.detectChanges();
+
+         const compiled = fixture.debugElement.nativeElement;
+
+         let content = getCollapsibleContent(compiled);
+
+         expect(hasClass(content, 'in')).toBe(true);
+         expect(content.getAttribute('aria-expanded') === "true").toBe(true);
+       });
+     }));
+
+  it('should have content closed  and aria-expanded false', injectAsync([TestComponentBuilder], (tcb) => {
+       return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         const tc = fixture.debugElement.componentInstance;
+         tc.collapsed = true;
+         fixture.detectChanges();
+
+         const compiled = fixture.debugElement.nativeElement;
+
+         let content = getCollapsibleContent(compiled);
+
+         expect(hasClass(content, 'in')).toBe(false);
+         expect(content.getAttribute('aria-expanded') === "false").toBe(true);
+       });
+     }));
+
+  it('should have height style of 0px', injectAsync([TestComponentBuilder], (tcb) => {
+       return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         const tc = fixture.debugElement.componentInstance;
+         tc.collapsed = true;
+         fixture.detectChanges();
+
+         const compiled = fixture.debugElement.nativeElement;
+
+         let content = getCollapsibleContent(compiled);
+
+         expect(hasStyle(content, 'height: 0px;')).toBe(true);
+       });
+     }));
+
+  it('should toggle collapsed content on click', injectAsync([TestComponentBuilder], (tcb) => {
+       return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         fixture.detectChanges();
+         const compiled = fixture.debugElement.nativeElement;
+         let content = getCollapsibleContent(compiled);
+         expect(hasClass(content, 'in')).toBe(true);
+
+         let buttonEl = getButton(compiled);
+
+         buttonEl.click();
+         fixture.detectChanges();
+         expect(hasClass(content, 'in')).toBe(false);
+
+         buttonEl.click();
+         fixture.detectChanges();
+         expect(hasClass(content, 'in')).toBe(true);
+
+       });
+     }));
+
+
+});
+
+@Component({selector: 'test-cmp', directives: [NgbCollapse], template: ''})
+class TestComponent {
+  collapsed = false;
+}

--- a/src/collapse/collapse.spec.ts
+++ b/src/collapse/collapse.spec.ts
@@ -26,10 +26,6 @@ function hasClass(element: Element, str: string): Boolean {
   return new RegExp(`(^|\\s)${str}(\\s|$)`).test(element.className);
 }
 
-function hasStyle(element: Element, str: string): Boolean {
-  return new RegExp(`(^|\\s)${str}(\\s|$)`).test(element.getAttribute('style'));
-}
-
 describe('ngb-collapse', () => {
   let html: string;
 
@@ -71,20 +67,6 @@ describe('ngb-collapse', () => {
 
          expect(hasClass(content, 'in')).toBe(false);
          expect(content.getAttribute('aria-expanded') === "false").toBe(true);
-       });
-     }));
-
-  it('should have height style of 0px', injectAsync([TestComponentBuilder], (tcb) => {
-       return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
-         const tc = fixture.debugElement.componentInstance;
-         tc.collapsed = true;
-         fixture.detectChanges();
-
-         const compiled = fixture.debugElement.nativeElement;
-
-         let content = getCollapsibleContent(compiled);
-
-         expect(hasStyle(content, 'height: 0px;')).toBe(true);
        });
      }));
 

--- a/src/collapse/collapse.spec.ts
+++ b/src/collapse/collapse.spec.ts
@@ -22,7 +22,6 @@ function getButton(element) {
   return element.querySelector('button');
 }
 
-
 function hasClass(element: Element, str: string): Boolean {
   return new RegExp(`(^|\\s)${str}(\\s|$)`).test(element.className);
 }
@@ -60,7 +59,7 @@ describe('ngb-collapse', () => {
        });
      }));
 
-  it('should have content closed  and aria-expanded false', injectAsync([TestComponentBuilder], (tcb) => {
+  it('should have content closed and aria-expanded false', injectAsync([TestComponentBuilder], (tcb) => {
        return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
          const tc = fixture.debugElement.componentInstance;
          tc.collapsed = true;
@@ -105,11 +104,8 @@ describe('ngb-collapse', () => {
          buttonEl.click();
          fixture.detectChanges();
          expect(hasClass(content, 'in')).toBe(true);
-
        });
      }));
-
-
 });
 
 @Component({selector: 'test-cmp', directives: [NgbCollapse], template: ''})

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -2,26 +2,8 @@ import {Directive, Input} from 'angular2/angular2';
 
 @Directive({
   selector: '[ngb-collapse]',
-  host: {
-    'class': 'collapse',
-    '[class.in]': '!_collapsed',
-    '[attr.aria-expanded]': '!_collapsed',
-    '[style.height.px]': '_height'
-  }
+  host: {'class': 'collapse', '[class.in]': '!collapsed', '[attr.aria-expanded]': '!collapsed'}
 })
 export class NgbCollapse {
-  private _collapsed: boolean;
-  private _height: number;
-
-  constructor() {}
-
-  @Input('ngbCollapse')
-  set collapsed(value: boolean) {
-    this._collapsed = value;
-    this._setHeight()
-  }
-
-  get collapsed(): boolean { return this._collapsed; }
-
-  private _setHeight(): void { this._height = this._collapsed ? 0 : undefined; }
+  @Input('ngbCollapse') collapsed: boolean;
 }

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -1,0 +1,24 @@
+import {Directive, Input} from 'angular2/angular2';
+
+@Directive({
+  selector: '[ngb-collapse]',
+  host: {'class': 'collapse', '[class.in]': '_open', '[attr.aria-expanded]': '_open', '[style.height.px]': '_height'}
+})
+export class NgbCollapse {
+  private _open: boolean;
+  private _height: number;
+
+  constructor() { this._open = this.ngbCollapse; }
+
+  @Input()
+  private set ngbCollapse(value: boolean) {
+    this._open = !value;
+    if (this._open === true) {
+      this._height = undefined;
+    } else {
+      this._height = 0;
+    }
+  }
+
+  private get ngbCollapse(): boolean { return this._open; }
+}

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -2,27 +2,26 @@ import {Directive, Input} from 'angular2/angular2';
 
 @Directive({
   selector: '[ngb-collapse]',
-  host: {'class': 'collapse', '[class.in]': '_open', '[attr.aria-expanded]': '_open', '[style.height.px]': '_height'}
+  host: {
+    'class': 'collapse',
+    '[class.in]': '!_collapsed',
+    '[attr.aria-expanded]': '!_collapsed',
+    '[style.height.px]': '_height'
+  }
 })
 export class NgbCollapse {
-  private _open: boolean;
+  private _collapsed: boolean;
   private _height: number;
 
-  constructor() { this._open = this.ngbCollapse; }
+  constructor() {}
 
-  @Input()
-  set ngbCollapse(value: boolean) {
-    this._open = !value;
+  @Input('ngbCollapse')
+  set collapsed(value: boolean) {
+    this._collapsed = value;
     this._setHeight()
   }
 
-  get ngbCollapse(): boolean { return this._open; }
+  get collapsed(): boolean { return this._collapsed; }
 
-  private _setHeight() {
-    if (this._open === true) {
-      this._height = undefined;
-    } else {
-      this._height = 0;
-    }
-  }
+  private _setHeight(): void { this._height = this._collapsed ? 0 : undefined; }
 }

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -11,14 +11,18 @@ export class NgbCollapse {
   constructor() { this._open = this.ngbCollapse; }
 
   @Input()
-  private set ngbCollapse(value: boolean) {
+  set ngbCollapse(value: boolean) {
     this._open = !value;
+    this._setHeight()
+  }
+
+  get ngbCollapse(): boolean { return this._open; }
+
+  private _setHeight() {
     if (this._open === true) {
       this._height = undefined;
     } else {
       this._height = 0;
     }
   }
-
-  private get ngbCollapse(): boolean { return this._open; }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,8 +1,10 @@
 import {NgbAccordion, NgbAccordionGroup} from './accordion/accordion';
+import {NgbCollapse} from './collapse/collapse';
 import {NgbDropdown} from './dropdown/dropdown';
 import {NgbRating} from './rating/rating';
 
 export {NgbAccordion, NgbAccordionGroup} from './accordion/accordion';
+export {NgbCollapse} from './collapse/collapse';
 export {NgbDropdown} from './dropdown/dropdown';
 export {NgbRating} from './rating/rating';
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,4 +8,4 @@ export {NgbCollapse} from './collapse/collapse';
 export {NgbDropdown} from './dropdown/dropdown';
 export {NgbRating} from './rating/rating';
 
-export const NGB_DIRECTIVES = [NgbAccordion, NgbAccordionGroup, NgbDropdown, NgbRating];
+export const NGB_DIRECTIVES = [NgbAccordion, NgbAccordionGroup, NgbCollapse, NgbDropdown, NgbRating];


### PR DESCRIPTION
Initial implementation of collapse. Please advise for changes required. Will add a plunker for this.
Usage `<div [ngb-collapse]="collapsed">` where `collapsed` is a boolean on container component