### PR TITLE
feat(dropdown): support dropdown and dropups

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -1,6 +1,6 @@
 import {Directive, Input} from 'angular2/angular2';
 
-@Directive({selector: 'ngb-dropdown', exportAs: 'ngbDropdown', host: {'class': 'dropdown', '[class.open]': 'open'}})
+@Directive({selector: 'ngb-dropdown', exportAs: 'ngbDropdown', host: {'[class.open]': 'open'}})
 export class NgbDropdown {
   @Input() open: boolean;
 }


### PR DESCRIPTION
Here is a proposal to drop the automatic addition of the `dropdown` so we can support dropups as well: http://v4-alpha.getbootstrap.com/components/button-dropdown/#dropup-variation

An alternative is to introduce a switch attribute which boils down to:

```html
<ngb-dropdown class="dropdown">.../<ngb-dropdown> 
```

vs.

```html
<ngb-dropdown direction="down">.../<ngb-dropdown> 
```

Thoughts?