### PR TITLE
feat(dropdown): allow toggling dropdown from outside

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -63,6 +63,27 @@ describe('ngb-dropdown', () => {
          expect(dropdownEl).not.toHaveCssClass('open');
        });
      }));
+
+  it('should allow toggling dropdown from outside', injectAsync([TestComponentBuilder], (tcb) => {
+       const html = `
+      <button (click)="drop.open = !drop.open">Toggle</button>
+      <ngb-dropdown #drop="ngbDropdown"></ngb-dropdown>`;
+
+       return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         fixture.detectChanges();
+         const compiled = fixture.debugElement.nativeElement;
+         let dropdownEl = getDropdownEl(compiled);
+         let buttonEl = compiled.querySelector('button');
+
+         buttonEl.click();
+         fixture.detectChanges();
+         expect(dropdownEl).toHaveCssClass('open');
+
+         buttonEl.click();
+         fixture.detectChanges();
+         expect(dropdownEl).not.toHaveCssClass('open');
+       });
+     }));
 });
 
 @Component({selector: 'test-cmp', directives: [NgbDropdown], template: ``})

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -1,6 +1,6 @@
 import {Directive, Input} from 'angular2/angular2';
 
-@Directive({selector: 'ngb-dropdown', host: {'class': 'dropdown', '[class.open]': 'open'}})
+@Directive({selector: 'ngb-dropdown', exportAs: 'ngbDropdown', host: {'class': 'dropdown', '[class.open]': 'open'}})
 export class NgbDropdown {
   @Input() open: boolean;
 }


### PR DESCRIPTION
It covers a common use case where people want to toggle things programatically. In ng1 one would create an associated service to manage dropdowns / tooltips etc. With ng2 we've got much better story as we can simply expose a component instance and allow people to write code to toggle things at will.

Check the test for more details.