### PR TITLE
refactor(accordion): rename NgbAccordionGroup to NgbAccordionPanel

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -12,10 +12,10 @@ import {
 
 import {Component} from 'angular2/angular2';
 
-import {NgbAccordion, NgbAccordionGroup} from './accordion';
+import {NgbAccordion, NgbAccordionPanel} from './accordion';
 
 function getPanels(element: Element): Element[] {
-  return Array.from(element.querySelectorAll('ngb-accordion-group .panel'));
+  return Array.from(element.querySelectorAll('ngb-accordion-panel .panel'));
 }
 
 function hasTitle(element: Element, str: string): Boolean {
@@ -28,21 +28,21 @@ describe('ngb-accordion', () => {
   beforeEach(() => {
     html = `
       <ngb-accordion [close-others]="closeOthers">
-        <ngb-accordion-group [is-open]="panels[0].open"
+        <ngb-accordion-panel [is-open]="panels[0].open"
           [title]="panels[0].title"
           [is-disabled]="panels[0].disabled">
           <div class="text-content">{{panels[0].content}}</div>
-        </ngb-accordion-group>
-        <ngb-accordion-group [is-open]="panels[1].open"
+        </ngb-accordion-panel>
+        <ngb-accordion-panel [is-open]="panels[1].open"
           [title]="panels[1].title"
           [is-disabled]="panels[1].disabled">
           <div class="text-content">{{panels[1].content}}</div>
-        </ngb-accordion-group>
-        <ngb-accordion-group [is-open]="panels[2].open"
+        </ngb-accordion-panel>
+        <ngb-accordion-panel [is-open]="panels[2].open"
           [title]="panels[2].title"
           [is-disabled]="panels[2].disabled">
           <div class="text-content">{{panels[2].content}}</div>
-        </ngb-accordion-group>
+        </ngb-accordion-panel>
       </ngb-accordion>
     `;
   });
@@ -212,7 +212,7 @@ describe('ngb-accordion', () => {
      }));
 });
 
-@Component({selector: 'test-cmp', directives: [NgbAccordion, NgbAccordionGroup], template: ''})
+@Component({selector: 'test-cmp', directives: [NgbAccordion, NgbAccordionPanel], template: ''})
 class TestComponent {
   closeOthers = false;
   panels: any[] = [

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -3,7 +3,7 @@ import {Component, Directive, forwardRef, Inject, Input, Query, QueryList} from 
 import {NgbCollapse} from '../collapse/collapse';
 
 @Component({
-  selector: 'ngb-accordion-group',
+  selector: 'ngb-accordion-panel',
   directives: [NgbCollapse],
   template: `
     <div class="panel panel-default" [class.panel-open]="isOpen">
@@ -20,7 +20,7 @@ import {NgbCollapse} from '../collapse/collapse';
     </div>
   `
 })
-export class NgbAccordionGroup {
+export class NgbAccordionPanel {
   private _isOpen = false;
   @Input() isDisabled: boolean;
   @Input() title: string;
@@ -49,16 +49,16 @@ export class NgbAccordionGroup {
 export class NgbAccordion {
   @Input('closeOthers') onlyOneOpen: boolean;
 
-  constructor(@Query(NgbAccordionGroup) public groups: QueryList<NgbAccordionGroup>) {}
+  constructor(@Query(NgbAccordionPanel) public panels: QueryList<NgbAccordionPanel>) {}
 
-  closeOthers(openGroup: NgbAccordionGroup): void {
+  closeOthers(openPanel: NgbAccordionPanel): void {
     if (!this.onlyOneOpen) {
       return;
     }
 
-    this.groups.toArray().forEach((group: NgbAccordionGroup) => {
-      if (group !== openGroup) {
-        group.isOpen = false;
+    this.panels.toArray().forEach((panel: NgbAccordionPanel) => {
+      if (panel !== openPanel) {
+        panel.isOpen = false;
       }
     });
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,11 +1,11 @@
-import {NgbAccordion, NgbAccordionGroup} from './accordion/accordion';
+import {NgbAccordion, NgbAccordionPanel} from './accordion/accordion';
 import {NgbCollapse} from './collapse/collapse';
 import {NgbDropdown} from './dropdown/dropdown';
 import {NgbRating} from './rating/rating';
 
-export {NgbAccordion, NgbAccordionGroup} from './accordion/accordion';
+export {NgbAccordion, NgbAccordionPanel} from './accordion/accordion';
 export {NgbCollapse} from './collapse/collapse';
 export {NgbDropdown} from './dropdown/dropdown';
 export {NgbRating} from './rating/rating';
 
-export const NGB_DIRECTIVES = [NgbAccordion, NgbAccordionGroup, NgbCollapse, NgbDropdown, NgbRating];
+export const NGB_DIRECTIVES = [NgbAccordion, NgbAccordionPanel, NgbCollapse, NgbDropdown, NgbRating];


### PR DESCRIPTION
Group is not a great name since we are not grouping anything here. The NgbAccordionPanel is close to the actual css class names used (and funnily enough we were already referring to those things as "panels" in tests) 