### PR TITLE
chore: add a contribution note to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,7 @@ See [this](https://github.com/angular/angular/blob/master/README.md) for up-to-d
 
 ## Contributing to the project
 
+**NOTE: We appreciate all the interest and enthusiasm, but this project is just in such a volatile state right now that we can't guarantee that your PR is going to be merged.
+It is highly recommended to open an issue (or write in the existing ones) and discuss possible collaborations.**
+
 We are always looking for the quality contributions! Please check the [CONTRIBUTING.md](CONTRIBUTING.md) doc for contribution guidelines.


### PR DESCRIPTION
I want to add this note because in the state we are with the project right now, we cannot allow people to waste their time making PRs.

We make lot of decisions everyday, we change lots of code too, and I feel bad if I have to close someones PR because it is not the way we want to implement it and we cannot afford to walk that person PR in the way we want it.

As soon as this volatile state disappear, well, I am more than happy to get all PRs possible.