### PR TITLE
refactor(rating): remove NgFor from required directives

### DIFF
--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, NgFor, EventEmitter, OnInit} from 'angular2/angular2';
+import {Component, Input, Output, EventEmitter, OnInit} from 'angular2/angular2';
 
 @Component({
   selector: 'ngb-rating',
@@ -9,8 +9,7 @@ import {Component, Input, Output, NgFor, EventEmitter, OnInit} from 'angular2/an
         <i class="glyphicon {{index < rate ? 'glyphicon-star' : 'glyphicon-star-empty'}}" (mouseenter)="enter(index + 1)" (click)="update(index + 1)" [title]="r.title" [attr.aria-valuetext]="r.title"></i>
       </template>
     </span>
-  `,
-  directives: [NgFor]
+  `
 })
 export class NgbRating implements OnInit {
   @Input() max = 10;


### PR DESCRIPTION
As for alpha .46, there is no need to explicitly add core directives anymore, they are loaded at bootstrap.