### PR TITLE
feat(progressbar): manage values below 0 and bigger than max

### DIFF
--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -36,6 +36,28 @@ describe('ng-progressbar', () => {
       progressCmp.value = 30;
       expect(progressCmp.calculatePercentage()).toBe(20);
     });
+
+    it('should set the value to 0 for negative numbers', () => {
+      progressCmp.value = -20;
+      expect(progressCmp.value).toBe(0);
+    });
+
+    it('should set the value to max if it is higher than max (default max size)', () => {
+      progressCmp.value = 120;
+      expect(progressCmp.value).toBe(100);
+    });
+
+    it('should set the value to max if it is higher than max (custom max size)', () => {
+      progressCmp.max = 150;
+      progressCmp.value = 170;
+      expect(progressCmp.value).toBe(150);
+    });
+
+    it('should update the value if max updates to a smaller value', () => {
+      progressCmp.value = 80;
+      progressCmp.max = 70;
+      expect(progressCmp.value).toBe(70);
+    });
   });
 
   describe('UI logic', () => {

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -11,9 +11,17 @@ import {Component, Input} from 'angular2/angular2';
   `
 })
 export class NgbProgressbar {
+  private _max = 100;
   private _striped: boolean;
+  private _value: number;
 
-  @Input() max = 100;
+  @Input()
+  set max(value: number) {
+    this._max = value;
+    this.value = Math.min(this.value, this._max);
+  }
+
+  get max(): number { return this._max; }
 
   @Input()
   set striped(value: boolean | string) {
@@ -28,7 +36,12 @@ export class NgbProgressbar {
 
   @Input() type: string;
 
-  @Input() value: number;
+  @Input()
+  set value(value: number) {
+    this._value = Math.max(Math.min(value, this.max), 0);
+  }
+
+  get value(): number { return this._value; }
 
   calculatePercentage() { return 100 * this.value / this.max; }
 }


### PR DESCRIPTION
This is the solution I had in mind.

If the value is less than 0, put it at 0, if more than 0, set it to max. If max changes, change value.

There are stuff to discuss about `max` typing, so hold this until meeting.