### PR TITLE
test(progressbar): expose problem with order of setters invocation

### DIFF
--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -21,9 +21,11 @@ describe('ng-progressbar', () => {
 
     it('should calculate the percentage (default max size)', () => {
       progressCmp.value = 50;
+      progressCmp.onChanges();
       expect(progressCmp.calculatePercentage()).toBe(50);
 
       progressCmp.value = 25;
+      progressCmp.onChanges();
       expect(progressCmp.calculatePercentage()).toBe(25);
     });
 
@@ -31,32 +33,45 @@ describe('ng-progressbar', () => {
       progressCmp.max = 150;
 
       progressCmp.value = 75;
+      progressCmp.onChanges();
       expect(progressCmp.calculatePercentage()).toBe(50);
 
       progressCmp.value = 30;
+      progressCmp.onChanges();
       expect(progressCmp.calculatePercentage()).toBe(20);
     });
 
     it('should set the value to 0 for negative numbers', () => {
       progressCmp.value = -20;
+      progressCmp.onChanges();
       expect(progressCmp.value).toBe(0);
     });
 
     it('should set the value to max if it is higher than max (default max size)', () => {
       progressCmp.value = 120;
+      progressCmp.onChanges();
       expect(progressCmp.value).toBe(100);
     });
 
     it('should set the value to max if it is higher than max (custom max size)', () => {
       progressCmp.max = 150;
       progressCmp.value = 170;
+      progressCmp.onChanges();
       expect(progressCmp.value).toBe(150);
     });
 
     it('should update the value if max updates to a smaller value', () => {
       progressCmp.value = 80;
       progressCmp.max = 70;
+      progressCmp.onChanges();
       expect(progressCmp.value).toBe(70);
+    });
+
+    it('should not update the value if max updates to a larger value', () => {
+      progressCmp.value = 120;
+      progressCmp.max = 150;
+      progressCmp.onChanges();
+      expect(progressCmp.value).toBe(120);
     });
   });
 
@@ -86,6 +101,15 @@ describe('ng-progressbar', () => {
            fixture.debugElement.componentInstance.max = 200;
            fixture.detectChanges();
            expect(getBarWidth(fixture.debugElement.nativeElement)).toBe('5%');
+         });
+       }));
+
+    it('accepts a value and max value above default values', injectAsync([TestComponentBuilder], (tcb) => {
+         const html = '<ngb-progressbar [value]="150" [max]="150"></ngb-progressbar>';
+
+         return tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.detectChanges();
+           expect(getBarWidth(fixture.debugElement.nativeElement)).toBe('100%');
          });
        }));
 

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from 'angular2/angular2';
+import {Component, Input, OnChanges} from 'angular2/angular2';
 
 @Component({
   selector: 'ngb-progressbar',
@@ -10,18 +10,11 @@ import {Component, Input} from 'angular2/angular2';
     </progress>
   `
 })
-export class NgbProgressbar {
-  private _max = 100;
+export class NgbProgressbar implements OnChanges {
   private _striped: boolean;
-  private _value: number;
 
-  @Input()
-  set max(value: number) {
-    this._max = value;
-    this.value = Math.min(this.value, this._max);
-  }
-
-  get max(): number { return this._max; }
+  @Input() max = 100;
+  @Input() value: number;
 
   @Input()
   set striped(value: boolean | string) {
@@ -36,12 +29,7 @@ export class NgbProgressbar {
 
   @Input() type: string;
 
-  @Input()
-  set value(value: number) {
-    this._value = Math.max(Math.min(value, this.max), 0);
-  }
-
-  get value(): number { return this._value; }
+  onChanges() { this.value = Math.max(Math.min(this.value, this.max), 0); }
 
   calculatePercentage() { return 100 * this.value / this.max; }
 }


### PR DESCRIPTION
I'm not sure if I was clear during yesterday's meeting about the issue we can see here in this test but the basic problem with setters influencing state is that we might end up with different state depending on the order of setters invocation. And we can't control this order!

Having the problem clear we can have a basic rule here: we can't calculate / update state in setters! All our directives (pagination, progress and rating) currently suffer from the problem exposed here.

Sending a PR to make everyone aware of the issue.