### PR TITLE
chore: add tooling for demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /typings/
 /dist/
 /temp/
+/demo/node_modules/
+/demo/dist/
 npm-debug.log
+.publish
 .sw*
 .idea

--- a/demo/src/demo.ts
+++ b/demo/src/demo.ts
@@ -1,0 +1,12 @@
+import {Component, bootstrap} from 'angular2/angular2';
+
+@Component({
+  selector: 'demo',
+  template: `
+    <div>Hello World</div>
+  `
+})
+class Demo {
+}
+
+bootstrap(Demo);

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ng-bootstrap</title>
+</head>
+<body>
+  <demo></demo>
+</body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,13 +3,17 @@ var ts = require('gulp-typescript');
 var gutil = require('gulp-util');
 var sourcemaps = require('gulp-sourcemaps');
 var ddescribeIit = require('gulp-ddescribe-iit');
+var shell = require('gulp-shell');
+var ghPages = require('gulp-gh-pages');
 var del = require('del');
 var merge = require('merge2');
 var clangFormat = require('clang-format');
 var gulpFormat = require('gulp-clang-format');
 var runSequence = require('run-sequence');
+var webpack = require('webpack');
+var webpackDemoConfig = require('./webpack.demo.js');
 
-var PATHS = {src: 'src/**/*.ts', specs: 'src/**/*.spec.ts'};
+var PATHS = {src: 'src/**/*.ts', specs: 'src/**/*.spec.ts', demo: 'demo/**/*.ts', demoDist: 'demo/dist/**/*'};
 
 // Transpiling & Building
 
@@ -24,7 +28,6 @@ gulp.task('cjs', function() {
 });
 
 gulp.task('umd', function(cb) {
-  var webpack = require('webpack');
   webpack(
       {
         entry: './dist/cjs/core.js',
@@ -61,26 +64,26 @@ function startKarmaServer(isTddMode, done) {
 
 gulp.task('clean:tests', function() { return del('temp/'); });
 
-gulp.task('build-tests', function() {
+gulp.task('build:tests', function() {
   var tsResult = gulp.src(PATHS.src).pipe(sourcemaps.init()).pipe(ts(testProject));
 
   return tsResult.js.pipe(sourcemaps.write('.')).pipe(gulp.dest('temp'));
 });
 
-gulp.task('clean-build-tests', function(done) { runSequence('clean:tests', 'build-tests', done); });
+gulp.task('clean:build-tests', function(done) { runSequence('clean:tests', 'build:tests', done); });
 
 gulp.task(
     'ddescribe-iit', function() { return gulp.src(PATHS.specs).pipe(ddescribeIit({allowDisabledTests: false})); });
 
-gulp.task('test', ['clean-build-tests'], function(done) { startKarmaServer(false, done); });
+gulp.task('test', ['clean:build-tests'], function(done) { startKarmaServer(false, done); });
 
-gulp.task('tdd', ['clean-build-tests'], function(done) {
+gulp.task('tdd', ['clean:build-tests'], function(done) {
   startKarmaServer(true, function(err) {
     done(err);
     process.exit(1);
   });
 
-  gulp.watch(PATHS.src, ['build-tests']);
+  gulp.watch(PATHS.src, ['build:tests']);
 });
 
 
@@ -100,13 +103,38 @@ gulp.task('enforce-format', function() {
 });
 
 function doCheckFormat() {
-  return gulp.src(['gulpfile.js', 'karma-test-shim.js', PATHS.src]).pipe(gulpFormat.checkFormat('file', clangFormat));
+  return gulp.src(['gulpfile.js', 'karma-test-shim.js', PATHS.src, PATHS.demo])
+      .pipe(gulpFormat.checkFormat('file', clangFormat));
 }
+
+// Demo
+
+gulp.task('clean:demo', function() { return del('demo/dist'); });
+
+gulp.task('clean:demo-cache', function() { return del('.publish/'); });
+
+gulp.task('demo-server', shell.task(['webpack-dev-server --config webpack.demo.js --inline --progress']));
+
+gulp.task('build:demo', function(done) {
+  var config = Object.create(webpackDemoConfig);
+  config.plugins = config.plugins.concat(new webpack.optimize.UglifyJsPlugin());
+
+  webpack(config, function(err, stats) {
+    if (err) throw new gutil.PluginError('build:demo', err);
+    gutil.log('[build:demo]', stats.toString({colors: true}));
+    done();
+  });
+});
+
+gulp.task('demo-push', function() { return gulp.src(PATHS.demoDist).pipe(ghPages()); });
 
 // Public Tasks
 
 gulp.task('build', function(done) {
   runSequence('enforce-format', 'ddescribe-iit', 'test', 'clean:build', 'cjs', 'umd', done);
 });
+
+gulp.task(
+    'deploy-demo', function(done) { runSequence('clean:demo', 'build:demo', 'demo-push', 'clean:demo-cache', done); });
 
 gulp.task('default', function(done) { runSequence('enforce-format', 'ddescribe-iit', 'test', done); });

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
     "gulp": "^3.9.0",
     "gulp-clang-format": "^1.0.21",
     "gulp-ddescribe-iit": "^1.3.0",
+    "gulp-gh-pages": "^0.5.4",
+    "gulp-shell": "^0.5.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-typescript": "^2.9.2",
     "gulp-util": "^3.0.6",
+    "html-webpack-plugin": "^1.7.0",
     "jasmine": "^2.3.2",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.14",
@@ -36,9 +39,13 @@
     "karma-jasmine": "^0.3.6",
     "karma-sourcemap-loader": "^0.3.6",
     "merge2": "^0.3.6",
+    "reflect-metadata": "^0.1.2",
     "run-sequence": "^1.1.4",
     "systemjs": "^0.19.5",
+    "ts-loader": "^0.7.2",
     "typescript": "^1.6.2",
-    "webpack": "^1.12.2"
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.14.0",
+    "zone.js": "^0.5.8"
   }
 }

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -1,0 +1,54 @@
+var webpack = require('webpack');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: {
+    'angular2': [
+      'zone.js',
+      'reflect-metadata',
+      'angular2/angular2'
+    ],
+    'app': [
+      './demo/src/demo.ts'
+    ]
+  },
+  output: {
+    path: __dirname + '/demo/dist',
+    filename: '[name].bundle.js',
+    chunkFilename: '[name].bundle.js'
+  },
+  resolve: {
+    extensions: ['', '.ts', '.js']
+  },
+  devtool: 'eval',
+  module: {
+    loaders: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader'
+      }
+    ]
+  },
+  plugins: [
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'angular2',
+      minChunks: Infinity,
+      filename: 'angular2.bundle.js'
+    }),
+    new HtmlWebpackPlugin({
+      template: './demo/src/index.html',
+      inject: 'body'
+    })
+  ],
+  devServer: {
+    contentBase: './demo/dist',
+    stats: {
+      modules: false,
+      cached: false,
+      colors: true,
+      chunk: false
+    }
+  }
+};


### PR DESCRIPTION
Alrighty, this is what I was working on the past few days.

With this, we get complete automation for the demo site.

The idea is that we can do anything we want in `/demo` and by doing `$ gulp deploy-demo` it would "compile" the demo into `/demo/dist` and the content of that goes to `gh-pages` automagically.

Everything (webpack conf, deps) sits in root. The reason for that is that you cannot run certain commands from the root that would involve the children alone. So this a choice between webpack.conf + package.json for the demo but all demo related stuff should sit in the demo folder with a gulpfile. That is not good.

If we add more packages for the demo, they need to sit on the project's package.json, but that is not a big deal.

I am more wary about the automatic push to gh-pages. It is the automation we needed in ui-bootstrap but is quite limiting. I don't have versioned docs figured out (not needed yet) but with automation is a bit harder.

About the webpack config. I decided to create a separate bundle with angular 2 and dependencies and a bundle for the app itself (which will contain also ngbs).

For css I haven't decided anything yet. Bootstrap 4 is not bundled yet in npm (I guess) so I could put a <link> tag or download the .css directly into a folder in the demo. Also we need to decide if scss or less (not sure what bs4 uses, scss IIRC).

And of course, figure out how to lay a demo.

When this get merged, we can create a dummy page with BS4 as a welcoming page.

I created this demo in [here](https://github.com/Foxandxss/ngbs-demo-playground) and you can see the result in [here](http://foxandxss.github.io/ngbs-demo-playground/)