### PR TITLE
chore: add compiler settings to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
 node_js:
   - "4.2.1"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 before_install:
   - export DISPLAY=:99.0


### PR DESCRIPTION
I noticed [this message](https://travis-ci.org/angular-ui/bootstrap/builds/97249326) in UI Bootstrap's Travis, likely related to the set of devDependencies used - I ported those settings here since it seems like this might be relevant to us in the future.