### PR TITLE
feat: add input conversion utils

### DIFF
--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, Input, Output, OnChanges, ChangeDetectionStrategy} from 'angular2/core';
 import {NgFor} from 'angular2/common';
+import {getValueInRange, toInteger} from '../util/util';
 
 @Component({
   selector: 'ngb-pagination',
@@ -44,14 +45,14 @@ export class NgbPagination implements OnChanges {
 
   @Input()
   set collectionSize(value: number | string) {
-    this._collectionSize = parseInt(`${value}`, 10);
+    this._collectionSize = toInteger(value);
   }
 
   get collectionSize(): number | string { return this._collectionSize; }
 
   @Input()
   set pageSize(value: number | string) {
-    this._pageSize = parseInt(`${value}`, 10);
+    this._pageSize = toInteger(value);
   }
 
   get pageSize(): number | string { return this._pageSize; }
@@ -84,8 +85,5 @@ export class NgbPagination implements OnChanges {
     this._page = this._getPageNoInRange(this.page);
   }
 
-  private _getPageNoInRange(newPageNo): number {
-    // make sure that the selected page is within available pages range
-    return Math.max(Math.min(newPageNo, this.pages.length), 1);
-  }
+  private _getPageNoInRange(newPageNo): number { return getValueInRange(newPageNo, this.pages.length, 1); }
 }

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -1,4 +1,5 @@
 import {Component, Input, ChangeDetectionStrategy} from 'angular2/core';
+import {getValueInRange, toBoolean} from '../util/util';
 
 @Component({
   selector: 'ngb-progressbar',
@@ -17,9 +18,9 @@ export class NgbProgressbar {
   @Input() type: string;
   @Input() value: number;
 
-  isStriped(): boolean { return this.striped === '' ? true : !!this.striped; }
+  isStriped(): boolean { return toBoolean(this.striped); }
 
-  getValue() { return Math.max(Math.min(this.value, this.max), 0); }
+  getValue() { return getValueInRange(this.value, this.max); }
 
   getPercentValue() { return 100 * this.getValue() / this.max; }
 }

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,0 +1,72 @@
+import {
+  iit,
+  it,
+  ddescribe,
+  describe,
+  expect,
+  inject,
+  injectAsync,
+  TestComponentBuilder,
+  beforeEach,
+  beforeEachProviders
+} from 'angular2/testing';
+
+import {toBoolean, toInteger, getValueInRange} from './util';
+
+describe('util', () => {
+
+  describe('toBoolean', () => {
+
+    it('should be noop for booleans', () => {
+      expect(toBoolean(true)).toBeTruthy();
+      expect(toBoolean(false)).toBeFalsy();
+    });
+
+    it('should parse an empty string as truthy', () => { expect(toBoolean('')).toBeTruthy(); });
+
+    it('should parse any string as truthy', () => {
+      expect(toBoolean('foo')).toBeTruthy();
+      expect(toBoolean('true')).toBeTruthy();
+      expect(toBoolean('false')).toBeTruthy();
+    });
+
+  });
+
+  describe('toInteger', () => {
+
+    it('should be noop for integers', () => {
+      expect(toInteger(0)).toBe(0);
+      expect(toInteger(10)).toBe(10);
+    });
+
+    it('should act as Math.floor for numbers', () => {
+      expect(toInteger(0.1)).toBe(0);
+      expect(toInteger(0.9)).toBe(0);
+    });
+
+    it('should parse strings', () => {
+      expect(toInteger('0')).toBe(0);
+      expect(toInteger('10')).toBe(10);
+      expect(toInteger('10.1')).toBe(10);
+      expect(toInteger('10.9')).toBe(10);
+    });
+
+  });
+
+  describe('getValueInRange', () => {
+
+    it('should be noop for numbers in range', () => { expect(getValueInRange(5, 10, 0)).toBe(5); });
+
+    it('should do corrections in range', () => {
+      expect(getValueInRange(11, 10, 0)).toBe(10);
+      expect(getValueInRange(-1, 10, 0)).toBe(0);
+    });
+
+    it('should take 0 as a default min bound', () => {
+      expect(getValueInRange(11, 10)).toBe(10);
+      expect(getValueInRange(-1, 10)).toBe(0);
+    });
+
+  });
+
+});

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,0 +1,11 @@
+export function toBoolean(value: any): boolean {
+  return value === '' ? true : !!value;
+}
+
+export function toInteger(value: any): number {
+  return parseInt(`${value}`, 10);
+}
+
+export function getValueInRange(value: number, max: number, min = 0): number {
+  return Math.max(Math.min(value, max), min);
+}


### PR DESCRIPTION
Adding few utils so we can consistently deal with type conversion for `@Input` values. IMO we need to have such utils in order to:
* have once central place where we handle conversion logic (for example: shell `foo="{{false}}"` evaluate to `true` or `false`?)
* have consistent user experience across all directives

What worries me is that is is creating coupling between components (that is - we are going to have harder time moving each component to its own dedicated repository) so we might want to extract those utils into a separate NPM package at some point.

