### PR TITLE
chore: update to angular 2 beta 6

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -1,4 +1,4 @@
-// Tun on full stack traces in errors to help debugging
+// Turn on full stack traces in errors to help debugging
 Error.stackTraceLimit = Infinity;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
@@ -17,8 +17,14 @@ System.config({
   }
 });
 
-System.import('angular2/src/platform/browser/browser_adapter')
-    .then(function(browser_adapter) { browser_adapter.BrowserDomAdapter.makeCurrent(); })
+System.import('angular2/testing')
+    .then(function(testing) {
+      return System.import('angular2/platform/testing/browser').then(function(testing_platform_browser) {
+        testing.setBaseTestProviders(
+            testing_platform_browser.TEST_BROWSER_PLATFORM_PROVIDERS,
+            testing_platform_browser.TEST_BROWSER_APPLICATION_PROVIDERS);
+      });
+    })
     .then(function() { return Promise.all(resolveTestFiles()); })
     .then(function() { __karma__.start(); }, function(error) { __karma__.error(error.stack || error); });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/ng-bootstrap/core#readme",
   "devDependencies": {
-    "angular2": "2.0.0-beta.1",
+    "angular2": "2.0.0-beta.6",
     "clang-format": "^1.0.29",
     "del": "^2.0.2",
     "es6-promise": "^3.0.2",
@@ -48,6 +48,6 @@
     "typescript": "^1.6.2",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.14.0",
-    "zone.js": "0.5.10"
+    "zone.js": "0.5.14"
   }
 }

--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -169,7 +169,7 @@ describe('ngb-accordion', () => {
 
          const panels = getPanels(fixture.nativeElement);
 
-         fixture.debugElement.componentViewChildren[0].children[0].nativeElement.click();
+         fixture.debugElement.children[0].nativeElement.click();
          fixture.detectChanges();
 
          expect(panels[0]).not.toHaveCssClass('panel-open');


### PR DESCRIPTION
After trying beta 2, beta 3, beta 5, beta 6 seems to not have any potential issue.

This fails on the typings for jasmine but since this PR needs to be merged as is and the other is more opinion based, I am going to create another PR for that.