### PR TITLE
test(pagination): make tests pass on Chrome

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -41,6 +41,7 @@ describe('ngb-dropdown', () => {
        });
      }));
 
+
   it('should toggle open class', injectAsync([TestComponentBuilder], (tcb) => {
        const html = `<div ngbDropdown [open]="isOpen"></div>`;
 

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -14,9 +14,11 @@ import {getValueInRange, toInteger} from '../util/util';
             </a>
         </li>
 
-        <li *ngFor="#pageNumber of pages" class="page-item" [class.active]="pageNumber === page">
-          <a class="page-link" (click)="selectPage(pageNumber)">{{pageNumber}}</a>
-        </li>
+        <template ngFor #pageNumber [ngForOf]="pages">
+          <li class="page-item" [class.active]="pageNumber === page">
+            <a class="page-link" (click)="selectPage(pageNumber)">{{pageNumber}}</a>
+          </li>
+        </template>
 
         <li class="page-item" [class.disabled]="!hasNext()">
           <a aria-label="Next" class="page-link" (click)="selectPage(page+1)">


### PR DESCRIPTION
Don't ask me why but without this change pagination tests are failing in Chrome (perfectly fine in FFox, thus not visible on TravisCI)