### PR TITLE
feat(NgbDialog): add the NgbDialog helper service

### DIFF
--- a/src/dialog/dialog.spec.ts
+++ b/src/dialog/dialog.spec.ts
@@ -1,0 +1,57 @@
+import {Component} from "angular2/core";
+
+import {
+  iit,
+  it,
+  ddescribe,
+  describe,
+  expect,
+  inject,
+  injectAsync,
+  TestComponentBuilder,
+  beforeEach,
+  beforeEachProviders
+} from 'angular2/testing';
+
+
+import {NgbDialog, NgbDialogOpenResult} from './dialog';
+
+describe('NgbDialog', () => {
+
+  beforeEachProviders(() => [NgbDialog]);
+
+  it('should open a component into a container',
+     injectAsync(
+         [NgbDialog], (ngbDialog: NgbDialog) => {
+
+                          return ngbDialog.open([TestComponent]).then((result: NgbDialogOpenResult) => {
+                            expect(result.componentRefs.length).toBe(1);
+                            expect(result.componentRefs[0].componentType).toBe(TestComponent);
+                            expect(result.componentRefs[0].location.nativeElement).toHaveText('Test content');
+
+                            result.disposeAll();
+                          })}));
+
+  it('should open multiple components into a container',
+     injectAsync(
+         [NgbDialog], (ngbDialog: NgbDialog) => {
+
+                          return ngbDialog.open([TestComponent, OtherComponent]).then((result: NgbDialogOpenResult) => {
+                            expect(result.componentRefs.length).toBe(2);
+                            expect(result.componentRefs[0].componentType).toBe(TestComponent);
+                            expect(result.componentRefs[1].componentType).toBe(OtherComponent);
+                            expect(result.componentRefs[0].location.nativeElement).toHaveText('Test content');
+                            expect(result.componentRefs[1].location.nativeElement).toHaveText('Other content');
+
+                            result.disposeAll();
+                          })}));
+
+});
+
+@Component({selector: 'test-component', template: `Test content`})
+export class TestComponent {
+}
+
+@Component({selector: 'other-component', template: `Other content`})
+export class OtherComponent {
+}

--- a/src/dialog/dialog.ts
+++ b/src/dialog/dialog.ts
@@ -1,0 +1,40 @@
+import {Injectable, ComponentRef, DynamicComponentLoader, Injector, Component} from 'angular2/core';
+
+const CONTAINER_TAG_NAME = 'ngb-dialog-container';
+
+@Component({selector: CONTAINER_TAG_NAME, template: ''})
+class NgbDialogContainer {
+}
+
+export class NgbDialogOpenResult {
+  constructor(public componentRefs: ComponentRef[]) {}
+
+  disposeAll() {
+    this.componentRefs.forEach((component) => { component.dispose(); });
+  }
+}
+
+@Injectable()
+export class NgbDialog {
+  private _container: Promise<ComponentRef>;
+
+  constructor(private _dcl: DynamicComponentLoader, private _injector: Injector) {
+    var el = document.querySelector(CONTAINER_TAG_NAME);
+
+    if (!el) {
+      document.body.appendChild(document.createElement(CONTAINER_TAG_NAME));
+    }
+
+    this._container = this._dcl.loadAsRoot(NgbDialogContainer, CONTAINER_TAG_NAME, _injector);
+  }
+
+  open(content: any[]): Promise<NgbDialogOpenResult> {
+    return this._container.then((container: ComponentRef) => {
+      return Promise
+          .all(content.map((contentComponent) => {
+            return this._dcl.loadNextToLocation(contentComponent, container.location);
+          }))
+          .then((components: ComponentRef[]) => { return new NgbDialogOpenResult(components); });
+    });
+  }
+}


### PR DESCRIPTION
The NgbDialog service can be used to dynamically load
components next to the body element. This is an internal
service to be used by modals, popovers, tooltips etc.