### PR TITLE
chore: swap tests to webpack

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,8 +58,6 @@ gulp.task('umd', function(cb) {
 
 // Testing
 
-var testProject = ts.createProject('tsconfig.json');
-
 function startKarmaServer(isTddMode, done) {
   var karmaServer = require('karma').Server;
   var travis = process.env.TRAVIS;
@@ -74,28 +72,16 @@ function startKarmaServer(isTddMode, done) {
   new karmaServer(config, done).start();
 }
 
-gulp.task('clean:tests', function() { return del('temp/'); });
-
-gulp.task('build:tests', function() {
-  var tsResult = gulp.src([PATHS.src, PATHS.typings]).pipe(sourcemaps.init()).pipe(ts(testProject));
-
-  return tsResult.js.pipe(sourcemaps.write('.')).pipe(gulp.dest('temp'));
-});
-
-gulp.task('clean:build-tests', function(done) { runSequence('clean:tests', 'build:tests', done); });
-
 gulp.task(
     'ddescribe-iit', function() { return gulp.src(PATHS.specs).pipe(ddescribeIit({allowDisabledTests: false})); });
 
-gulp.task('test', ['clean:build-tests'], function(done) { startKarmaServer(false, done); });
+gulp.task('test', function(done) { startKarmaServer(false, done); });
 
-gulp.task('tdd', ['clean:build-tests'], function(done) {
+gulp.task('tdd', function(done) {
   startKarmaServer(true, function(err) {
     done(err);
     process.exit(1);
   });
-
-  gulp.watch(PATHS.src, ['build:tests']);
 });
 
 

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -1,59 +1,10 @@
-// Turn on full stack traces in errors to help debugging
 Error.stackTraceLimit = Infinity;
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+var appContext = require.context('./src', true, /\.spec\.ts/);
 
-// // Cancel Karma's synchronous start,
-// // we will call `__karma__.start()` later, once all the specs are loaded.
-__karma__.loaded = function() {};
+appContext.keys().forEach(appContext);
 
-System.config({
-  packages: {
-    'base/temp': {
-      defaultExtension: false,
-      format: 'cjs',
-      map: Object.keys(window.__karma__.files).filter(onlyAppFiles).reduce(createPathRecords, {})
-    }
-  }
-});
+var testing = require('angular2/testing');
+var browser = require('angular2/platform/testing/browser');
 
-System.import('angular2/testing')
-    .then(function(testing) {
-      return System.import('angular2/platform/testing/browser').then(function(testing_platform_browser) {
-        testing.setBaseTestProviders(
-            testing_platform_browser.TEST_BROWSER_PLATFORM_PROVIDERS,
-            testing_platform_browser.TEST_BROWSER_APPLICATION_PROVIDERS);
-      });
-    })
-    .then(function() { return Promise.all(resolveTestFiles()); })
-    .then(function() { __karma__.start(); }, function(error) { __karma__.error(error.stack || error); });
-
-function createPathRecords(pathsMapping, appPath) {
-  // creates local module name mapping to global path with karma's fingerprint in path, e.g.:
-  // './accordion/accordion':
-  // '/base/temp/accordion/accordion.js?f4523daf879cfb7310ef6242682ccf10b2041b3e'
-  var pathParts = appPath.split('/');
-  var moduleName = './' + pathParts.slice(Math.max(pathParts.length - 2, 1)).join('/');
-  moduleName = moduleName.replace(/\.js$/, '');
-  pathsMapping[moduleName] = appPath + '?' + window.__karma__.files[appPath];
-  return pathsMapping;
-}
-
-function onlyAppFiles(filePath) {
-  return /\/base\/temp\/(?!.*\.spec\.js$).*\.js$/.test(filePath);
-}
-
-function onlySpecFiles(path) {
-  return /\.spec\.js$/.test(path);
-}
-
-function resolveTestFiles() {
-  return Object
-      .keys(window.__karma__.files)  // All files served by Karma.
-      .filter(onlySpecFiles)
-      .map(function(moduleName) {
-        // loads all spec files via their global module names (e.g.
-        // 'base/temp/accordion/accordion.test')
-        return System.import(moduleName);
-      });
-}
+testing.setBaseTestProviders(browser.TEST_BROWSER_PLATFORM_PROVIDERS, browser.TEST_BROWSER_APPLICATION_PROVIDERS);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+var webpackConfig = require('./webpack.test');
+
 module.exports = function(config) {
   config.set({
 
@@ -6,25 +8,18 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
 
     files: [
-      // For travis
-      'node_modules/es6-shim/es6-shim.js',
-      // paths loaded by Karma
-      {pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: false},
+      {pattern: 'node_modules/es6-shim/es6-shim.js', included: true, watched: false},
       {pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', included: true, watched: false},
-      {pattern: 'node_modules/rxjs/bundles/Rx.js', included: true, watched: false},
-      {pattern: 'node_modules/angular2/bundles/angular2.js', included: true, watched: true},
-      {pattern: 'node_modules/angular2/bundles/testing.dev.js', included: true, watched: true},
-      {pattern: 'karma-test-shim.js', included: true, watched: true},
-
-      // paths loaded via module imports
-      {pattern: 'temp/**/*.js', included: false, watched: true},
-
-      // paths to support debugging with source maps in dev tools
-      {pattern: 'src/**/*.ts', included: false, watched: false},
-      {pattern: 'temp/**/*.js.map', included: false, watched: false}
+      {pattern: './karma-test-shim.js', watched: false}
     ],
 
-    preprocessors: {'temp/**/*.js': ['sourcemap']},
+    preprocessors: {'./karma-test-shim.js': ['webpack', 'sourcemap']},
+    
+    webpack: webpackConfig,
+    
+    webpackMiddleware: {
+      stats: 'errors-only'
+    },
 
     reporters: ['progress'],
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
     "karma-sourcemap-loader": "^0.3.6",
+    "karma-webpack": "^1.7.0",
     "merge2": "^1.0.1",
     "reflect-metadata": "0.1.2",
     "run-sequence": "^1.1.4",

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -1,0 +1,19 @@
+var path = require('path');
+
+module.exports = {
+  devtool: 'inline-source-map',
+  
+  resolve: {
+    extensions: ['', '.js', '.ts'],
+  },
+  
+  module: {
+    loaders: [
+      {
+        test: /\.ts$/,
+        loader: 'ts',
+        exclude: /node_modules/
+      }
+    ]
+  }
+};


### PR DESCRIPTION
So since I created all the tooling, I learnt a lot of new cool stuff so I am going to open a few PRs over the week.

First one, swap testing to karma.

Pros:

* All testing is done in memory, that means:
* No temp folder, so no more having to worry about stale code there.
* No need to have a transpilation in background for tdd mode.
* Sourcemaps? (not sure if we had that before)

* coverage (not here yet)
* proper linting (not here yet)

Cons:

* Our source needs to be webpack compatible, not an issue right now tho. Will see what the future bring us, but no problem as today.
