### PR TITLE
chore: update travis for node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: node_js
 node_js:
-  - "4.2.1"
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+  - "5"
 
 before_install:
   - export DISPLAY=:99.0


### PR DESCRIPTION
With frameworks and libraries moving to give only node 5 support and npm3, I prefer to bump travis as well to avoid surprises.

Also I think that all those extra options are not needed. Let say what travis has to say about this.