### PR TITLE
docs: accordion demo

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -5,6 +5,8 @@ import { HomeComponent } from './home';
 import { AccordionComponent } from './components/accordion';
 import { SideNavComponent } from './shared';
 
+import 'prismjs/themes/prism-okaidia.css';
+import 'bootstrap/dist/css/bootstrap.css';
 import '../style/app.scss';
 
 /*

--- a/demo/src/app/components/accordion/accordion.component.html
+++ b/demo/src/app/components/accordion/accordion.component.html
@@ -1,5 +1,35 @@
-<h1>Accordion page!</h1>
+<h3>{{accordionDocs.title}}</h3>
+
+<p>{{accordionDocs.description}}</p>
+
+<template ngFor let-input [ngForOf]="accordionDocs.inputs">
+  <ngbd-instructions-item [item]="input.item" [description]="input.description"></ngbd-instructions-item>
+</template>
+
+<h3>{{panelDocs.title}}</h3>
+
+<p>{{panelDocs.description}}</p>
+
+<template ngFor let-input [ngForOf]="panelDocs.inputs">
+  <ngbd-instructions-item [item]="input.item" [description]="input.description"></ngbd-instructions-item>
+</template>
+
+CODE:
+
+<ngb-tabset>
+  <ngb-tab title="typescript">
+    <template ngb-tab-content>
+      <pre class="language-typescript"><code class="language-typescript" [innerHTML]="basicTsContent"></code></pre>
+    </template>
+  </ngb-tab>
+  <ngb-tab title="html">
+    <template ngb-tab-content>
+      <pre class="language-html"><code class="language-html" [innerHTML]="basicHtmlContent"></code></pre>
+    </template>
+  </ngb-tab>
+</ngb-tabset>
 
 DEMO:
 
-<ngb-accordion></ngb-accordion>
+<ngbd-accordion-basic></ngbd-accordion-basic>
+

--- a/demo/src/app/components/accordion/accordion.component.ts
+++ b/demo/src/app/components/accordion/accordion.component.ts
@@ -1,24 +1,20 @@
 import { Component } from '@angular/core';
 
-import 'prismjs/themes/prism-okaidia.css';
+import { NgbTabContent, NgbTab, NgbTabset } from '../../../../../src/tabset/tabset';
+import { InstructionsItemComponent } from '../shared';
+import { AccordionBasicComponent, basicHtmlContent, basicTsContent } from './demos';
 
-// import { AccordionDemoComponent } from 'core/accordion/demo/demo.ts';
-
-// import { NgbAccordion } from '../../../../../core/src/accordion/accordion';
-
-import { NgbAccordion, NgbPanel } from '../../../../../src/accordion/accordion';
-
-// const demoMarkdown = require('./demo/demo.md');
-// const tsContent = require('!!prismjs?lang=typescript!./demo/demo.ts');
-// const htmlContent = require('!!prismjs?lang=markup!./demo/demo.html');
+const accordionDocs = require('./demos/ngb-accordion.json');
+const panelDocs = require('./demos/ngb-panel.json');
 
 @Component({
   selector: 'ngbd-accordion',
   template: require('./accordion.component.html'),
-  directives: [NgbAccordion, NgbPanel]
+  directives: [InstructionsItemComponent, NgbTab, NgbTabset, NgbTabContent, AccordionBasicComponent]
 })
 export class AccordionComponent {
-  // instructions = demoMarkdown;
-  // tsCode = tsContent;
-  // htmlCode = htmlContent;
+  accordionDocs = accordionDocs;
+  panelDocs = panelDocs;
+  basicHtmlContent = basicHtmlContent;
+  basicTsContent = basicTsContent;
 }

--- a/demo/src/app/components/accordion/demos/basic/basic.component.html
+++ b/demo/src/app/components/accordion/demos/basic/basic.component.html
@@ -1,0 +1,17 @@
+<p>
+  <button type="button" class="btn btn-primary btn-sm" (click)="isOpen = !isOpen">Toggle last panel</button>
+  <button type="button" class="btn btn-primary btn-sm" (click)="firstDisabled = !firstDisabled">Enable / Disable first panel</button>
+  <button type="button" class="btn btn-danger btn-sm" (click)="removeDynamic()">Remove last dynamic</button>
+</p>
+
+<ngb-accordion close-others="true">
+  <ngb-panel title="This is the header" [disabled]="firstDisabled" open="true">
+    This is the content
+  </ngb-panel>
+  <ngb-panel [title]="group.heading" *ngFor="let group of groups">
+    {{group.content}}
+  </ngb-panel>
+  <ngb-panel title="Another group" [open]="isOpen">
+    More content
+  </ngb-panel>
+</ngb-accordion>

--- a/demo/src/app/components/accordion/demos/basic/basic.component.ts
+++ b/demo/src/app/components/accordion/demos/basic/basic.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+
+import { NgbAccordion, NgbPanel } from '@ng-bootstrap/accordion';
+
+@Component({
+  selector: 'ngbd-accordion-basic',
+  template: require('./basic.component.html'),
+  directives: [NgbAccordion, NgbPanel]
+})
+export class AccordionBasicComponent {
+  firstDisabled = false;
+  isOpen = false;
+
+  groups = [
+    {
+      heading: 'Dynamic 1',
+      content: 'I am dynamic!'
+    },
+    {
+      heading: 'Dynamic 2',
+      content: 'Dynamic as well'
+    }
+  ];
+
+  removeDynamic() {
+    this.groups.pop();
+  }
+}

--- a/demo/src/app/components/accordion/demos/basic/index.ts
+++ b/demo/src/app/components/accordion/demos/basic/index.ts
@@ -1,0 +1,3 @@
+export * from './basic.component';
+export const basicTsContent = require('!!prismjs?lang=typescript!./basic.component.ts');
+export const basicHtmlContent = require('!!prismjs?lang=markup!./basic.component.html');

--- a/demo/src/app/components/accordion/demos/index.ts
+++ b/demo/src/app/components/accordion/demos/index.ts
@@ -1,0 +1,1 @@
+export * from './basic';

--- a/demo/src/app/components/accordion/demos/ngb-accordion.json
+++ b/demo/src/app/components/accordion/demos/ngb-accordion.json
@@ -1,0 +1,10 @@
+{
+  "title": "ngb-accordion",
+  "description": "This is an accordion and it rocks",
+  "inputs": [
+    {
+      "item": "closeOthers",
+      "description": "Whether the panel is open or closed."
+    }
+  ]
+}

--- a/demo/src/app/components/accordion/demos/ngb-panel.json
+++ b/demo/src/app/components/accordion/demos/ngb-panel.json
@@ -1,0 +1,18 @@
+{
+  "title": "ngb-panel",
+  "description": "This is an panel and it is good too.",
+  "inputs": [
+    {
+      "item": "disabled",
+      "description": "Whether the panel is disabled or not."
+    },
+    {
+      "item": "open",
+      "description": "Whether the panel is open or closed."
+    },
+    {
+      "item": "title",
+      "description": "The clickable text on the panel's header."
+    }
+  ]
+}

--- a/demo/src/app/components/shared/index.ts
+++ b/demo/src/app/components/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './instructions-item';

--- a/demo/src/app/components/shared/instructions-item/index.ts
+++ b/demo/src/app/components/shared/instructions-item/index.ts
@@ -1,0 +1,1 @@
+export * from './instructions-item.component';

--- a/demo/src/app/components/shared/instructions-item/instructions-item.component.html
+++ b/demo/src/app/components/shared/instructions-item/instructions-item.component.html
@@ -1,0 +1,6 @@
+<div>
+  <code>{{item}}</code>
+</div>
+<div>
+  {{description}}
+</div>

--- a/demo/src/app/components/shared/instructions-item/instructions-item.component.ts
+++ b/demo/src/app/components/shared/instructions-item/instructions-item.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ngbd-instructions-item',
+  template: require('./instructions-item.component.html')
+})
+export class InstructionsItemComponent {
+  @Input() item: string;
+  @Input() description: string;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@angular/platform-browser-dynamic": "2.0.0-rc.1",
     "@angular/router-deprecated": "^2.0.0-rc.1",
     "autoprefixer": "^6.3.6",
+    "bootstrap": "^4.0.0-alpha.2",
     "clang-format": "1.0.35",
     "copy-webpack-plugin": "^2.1.3",
     "css-loader": "^0.23.1",

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -65,7 +65,11 @@ module.exports = function makeWebpackConfig() {
   config.resolve = {
     root: root('demo'),
     // only discover files that have those extensions
-    extensions: ['', '.ts', '.js', '.json', '.css', '.scss', '.html']
+    extensions: ['', '.ts', '.js', '.json', '.css', '.scss', '.html'],
+
+    alias: {
+      '@ng-bootstrap/accordion': root('src/accordion/accordion.ts')
+    }
   };
 
   /**


### PR DESCRIPTION
Werk in progress.

I need to tidy up the code and stuff like that (the templates is another subject).

This setup will allow multiple demos per component (to show different features).

I tried to extract as much as possible in the json so in the future we can make this more generic.

Also notice how I imported the accordion in the demo (@ng-bootstrap/accordion) which is how we are going to use it in prod, so better to show in the demo that way. This alias won't work twice, so I will need to make changes on the core itself so each component is exported. We will probably need something like that for the scoped packages. I will think about this.

Probably a few things are horrible, but I am asleeeep.