### PR TITLE
feat(modal): bring back modal backdrop and window

### DIFF
--- a/src/modal/modal_backdrop.spec.ts
+++ b/src/modal/modal_backdrop.spec.ts
@@ -1,0 +1,15 @@
+import {iit, it, ddescribe, describe, expect, inject, async, beforeEachProviders} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+
+import {NgbModalBackdrop} from './modal_backdrop';
+
+describe('ngb-modal-backdrop', () => {
+
+  it('should render backdrop with required CSS classes', async(inject([TestComponentBuilder], (tcb) => {
+       tcb.createAsync(NgbModalBackdrop).then((fixture) => {
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement).toHaveCssClass('modal-backdrop');
+       });
+     })));
+});

--- a/src/modal/modal_backdrop.ts
+++ b/src/modal/modal_backdrop.ts
@@ -1,0 +1,5 @@
+import {Component} from "@angular/core";
+
+@Component({selector: 'ngb-modal-backdrop', template: '', host: {"class": "modal-backdrop"}})
+export class NgbModalBackdrop {
+}

--- a/src/modal/modal_dismiss_reasons.ts
+++ b/src/modal/modal_dismiss_reasons.ts
@@ -1,0 +1,4 @@
+export enum ModalDismissReasons {
+  BACKDROP_CLICK,
+  ESC
+}

--- a/src/modal/modal_window.spec.ts
+++ b/src/modal/modal_window.spec.ts
@@ -1,0 +1,94 @@
+import {
+  iit,
+  it,
+  ddescribe,
+  describe,
+  expect,
+  inject,
+  async,
+  beforeEach,
+  beforeEachProviders
+} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+
+import {NgbModalWindow} from './modal_window';
+import {ModalDismissReasons} from "./modal_dismiss_reasons";
+
+describe('ngb-modal-dialog', () => {
+
+  describe('basic rendering functionality', () => {
+
+    it('should render default modal window', async(inject([TestComponentBuilder], (tcb) => {
+         tcb.createAsync(NgbModalWindow).then((fixture) => {
+           fixture.detectChanges();
+
+           var modalEl: Element = fixture.nativeElement;
+           var dialogEl: Element = fixture.nativeElement.querySelector('.modal-dialog');
+
+           expect(modalEl).toHaveCssClass('modal');
+           expect(dialogEl).toHaveCssClass('modal-dialog');
+         });
+       })));
+
+    it('should render default modal window with a specified size', async(inject([TestComponentBuilder], (tcb) => {
+         tcb.createAsync(NgbModalWindow).then((fixture) => {
+
+           fixture.componentInstance.size = 'sm';
+           fixture.detectChanges();
+
+           var dialogEl: Element = fixture.nativeElement.querySelector('.modal-dialog');
+           expect(dialogEl).toHaveCssClass('modal-dialog');
+           expect(dialogEl).toHaveCssClass('modal-sm');
+         });
+       })));
+  });
+
+  describe('dismiss', () => {
+
+    var tcb: TestComponentBuilder;
+
+    beforeEach(inject([TestComponentBuilder], (tcBuilder) => { tcb = tcBuilder; }));
+
+    it('should dismiss on backdrop click by default', (done) => {
+      tcb.createAsync(NgbModalWindow).then((fixture) => {
+        fixture.detectChanges();
+
+        fixture.componentInstance.dismissEvent.subscribe(($event) => {
+          expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
+          done();
+        });
+
+        fixture.nativeElement.querySelector('.modal-dialog').click();
+      });
+    });
+
+    it('should ignore backdrop clicks when configured to do so', (done) => {
+      tcb.createAsync(NgbModalWindow).then((fixture) => {
+        fixture.componentInstance.backdrop = false;
+        fixture.detectChanges();
+
+        fixture.componentInstance.dismissEvent.subscribe(($event) => {
+          expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
+          done(new Error('Should not trigger dismiss event'));
+        });
+
+        fixture.nativeElement.querySelector('.modal-dialog').click();
+        setTimeout(done, 200);
+      });
+    });
+
+    it('should dismiss on esc press by default', (done) => {
+      tcb.createAsync(NgbModalWindow).then((fixture) => {
+        fixture.detectChanges();
+
+        fixture.componentInstance.dismissEvent.subscribe(($event) => {
+          expect($event).toBe(ModalDismissReasons.ESC);
+          done();
+        });
+
+        fixture.debugElement.triggerEventHandler('keyup.esc', {});
+      });
+    });
+  });
+
+});

--- a/src/modal/modal_window.ts
+++ b/src/modal/modal_window.ts
@@ -1,0 +1,49 @@
+import {
+  Component,
+  Output,
+  EventEmitter,
+  Input,
+  HostListener,
+} from "@angular/core";
+
+import {ModalDismissReasons} from './modal_dismiss_reasons';
+
+@Component({
+  selector: 'ngb-modal-window',
+  host: {"class": "modal", "role": "dialog", "tabindex": "-1", "style": "display: block;"},
+  template: `
+        <div [class]="'modal-dialog' + (size ? ' modal-' + size : '')">
+            <div class="modal-content" (click)="stopPropagation($event)">
+                <ng-content></ng-content>                          
+            </div>
+        </div>
+    `
+})
+export class NgbModalWindow {
+  @Input() backdrop = true;
+  @Input() keyboard = true;
+  @Input() size: string;
+
+  @Output('close') closeEvent = new EventEmitter();
+  @Output('dismiss') dismissEvent = new EventEmitter();
+
+  @HostListener('click')
+  backdropClick(): void {
+    if (this.backdrop) {
+      this.dismiss(ModalDismissReasons.BACKDROP_CLICK);
+    }
+  }
+
+  @HostListener('keyup.esc')
+  escKey(): void {
+    if (this.keyboard) {
+      this.dismiss(ModalDismissReasons.ESC);
+    }
+  }
+
+  close(result): void { this.closeEvent.emit(result); }
+
+  dismiss(reason): void { this.dismissEvent.emit(reason); }
+
+  stopPropagation($event: MouseEvent): void { $event.stopPropagation(); }
+}


### PR DESCRIPTION
This PR brings back modal's window and backdrop components previously removed in 1f34c8781dca3d371e4543917834b4846fb6a292. The good news is that we don't need _that_ much gymnastic to load modal's content. By using a technique demonstrated [here](https://github.com/ng-bootstrap/core/issues/2#issuecomment-218851066) we can use regular `<ng-content>` and insert content synchronously.   