### PR TITLE
chore(apiDocs): properly report boolean default values in inputs

### DIFF
--- a/misc/api-doc-test-cases/directives-with-inputs-default-vals.ts
+++ b/misc/api-doc-test-cases/directives-with-inputs-default-vals.ts
@@ -1,0 +1,11 @@
+import {Directive, Input} from '@angular/core';
+
+@Directive({
+  selector: '[foo]'
+})
+export class Foo {
+
+  @Input() fooBoolean: boolean = false;
+  @Input() fooNumber: number = 5;
+  @Input() fooString: string = 'bar';
+}

--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -104,10 +104,20 @@ class APIDocVisitor {
     var inArgs = inDecorator.expression.arguments;
     return {
       name: inArgs.length ? inArgs[0].text : property.name.text,
-      defaultValue: property.initializer ? property.initializer.text : undefined,
+      defaultValue: property.initializer ? this.stringifyDefaultValue(property.initializer) : undefined,
       type: this.stringifyTypeInfo(property.type),
       description: ts.displayPartsToString(property.symbol.getDocumentationComment())
     };
+  }
+
+  stringifyDefaultValue(node) {
+    if (node.text) {
+      return node.text;
+    } else if (node.kind === ts.SyntaxKind.FalseKeyword) {
+      return 'false';
+    } else if (node.kind === ts.SyntaxKind.TrueKeyword) {
+      return 'true';
+    }
   }
 
   visitOutput(property, outDecorator) {

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -44,6 +44,16 @@ describe('APIDocVisitor', function() {
     expect(inputDocs[2].description).toBe('Has default value');
   });
 
+  it('should extract input default value', function() {
+    var inputDocs = apiDoc(['./misc/api-doc-test-cases/directives-with-inputs-default-vals.ts']).Foo.inputs;
+
+    expect(inputDocs.length).toBe(3);
+
+    expect(inputDocs[0].defaultValue).toBe('false');
+    expect(inputDocs[1].defaultValue).toBe('5');
+    expect(inputDocs[2].defaultValue).toBe('bar');
+  });
+
   it('should extract inputs info from setters', function() {
     var inputDocs = apiDoc(['./misc/api-doc-test-cases/directives-with-tricky-inputs.ts']).Foo.inputs;
 


### PR DESCRIPTION
While working on the docs I've noticed that boolean default values are not extracted properly. Here is the fix.