### PR TITLE
chore: update to typings 1.x

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -50,13 +50,15 @@ cd ng-bootstrap
 git remote add upstream https://github.com/ng-bootstrap/core.git
 ```
 
-## Installing NPM Modules
+## Installing NPM Modules and typings
 
 Next, install the JavaScript modules needed to build and test ng-bootstrap:
 
 ```shell
 # Install ng-bootstrap project dependencies (package.json)
 npm install
+# Install types
+npm run typings install
 ```
 
 Globally install gulp as follows:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ var PATHS = {
   specs: 'src/**/*.spec.ts',
   demo: 'demo/**/*.ts',
   demoDist: 'demo/dist/**/*',
-  typings: 'typings/browser.d.ts',
+  typings: 'typings/index.d.ts',
   demoDocsJson: 'demo/src/docs.json'
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "install": "node misc/validate-commit.install.js",
     "test": "karma start karma.conf.js",
-    "postinstall": "typings install"
+    "typings": "typings"
   },
   "repository": {
     "type": "git",
@@ -70,7 +70,7 @@
     "ts-loader": "^0.8.2",
     "tslint": "^3.8.1",
     "typescript": "^1.6.2",
-    "typings": "^0.7.9",
+    "typings": "^1.3.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.14.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,5 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true
   },
-  "compileOnSave": false,
-  "exclude": [
-    "node_modules",
-    "typings/main",
-    "typings/main.d.ts"
-  ]
+  "compileOnSave": false
 }

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,7 @@
 {
-  "ambientDevDependencies": {
-    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#7de6c3dd94feaeb21f20054b9f30d5dabc5efabd",
-    "node": "registry:dt/node#4.0.0+20160509082809"
-  },
-  "ambientDependencies": {
-    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#7de6c3dd94feaeb21f20054b9f30d5dabc5efabd"
+  "globalDependencies": {
+    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
+    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
+    "node": "registry:dt/node#6.0.0+20160621231320"
   }
 }


### PR DESCRIPTION
Changes:

New typings with its breaking changes.
I removed the postinstall. A library **shouldn't** have it because that will force all consumers to have typings installed globally and that is a no-no, so from now one, manual install for us (this doesn't involve anything for the end user).

Please delete your typings folder and install them again.