### PR TITLE
chore(demo): add prismjs as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "merge2": "^1.0.1",
     "node-sass": "^3.7.0",
     "postcss-loader": "^0.9.1",
+    "prismjs": "^1.5.1",
     "prismjs-loader": "0.0.3",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "0.1.2",


### PR DESCRIPTION
We have an `import 'prismjs/themes/prism-okaidia.css';` statement in _app.component.ts_ but we don't have prismjs as dependency due to which `gulp demo-server` fails