### PR TITLE
feat(pagination): add first/last buttons

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -207,6 +207,37 @@ describe('ngb-pagination', () => {
            expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
          });
        })));
+
+    it('should update selected page model on first / last click', async(inject([TestComponentBuilder], (tcb) => {
+         const html =
+             '<ngb-pagination [collectionSize]="collectionSize" [page]="page" [boundaryLinks]="boundaryLinks"></ngb-pagination>';
+
+         tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+           fixture.componentInstance.collectionSize = 30;
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+
+           fixture.componentInstance.boundaryLinks = true;
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+
+           getLink(fixture.nativeElement, 0).click();
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+
+           getLink(fixture.nativeElement, 6).click();
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '2', '+3', '-» Next', '-»» Last']);
+
+           getLink(fixture.nativeElement, 3).click();
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '+2', '3', '» Next', '»» Last']);
+
+           getLink(fixture.nativeElement, 0).click();
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+         });
+       })));
   });
 
 });
@@ -216,4 +247,5 @@ class TestComponent {
   pageSize = 10;
   collectionSize = 100;
   page = 1;
+  boundaryLinks = false;
 }

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, Input, Output, OnChanges, ChangeDetectionStrategy} from '@angular/core';
-import {getValueInRange, toInteger} from '../util/util';
+import {getValueInRange, toInteger, toBoolean} from '../util/util';
 
 @Component({
   selector: 'ngb-pagination',
@@ -7,11 +7,18 @@ import {getValueInRange, toInteger} from '../util/util';
   template: `
     <nav>
       <ul class="pagination">
+        <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasPrevious()">
+          <a aria-label="First" class="page-link" (click)="selectPage(1)">
+            <span aria-hidden="true">&laquo;&laquo;</span>
+            <span class="sr-only">First</span>
+          </a>                
+        </li>
+      
         <li class="page-item" [class.disabled]="!hasPrevious()">
-            <a aria-label="Previous" class="page-link" (click)="selectPage(page-1)">
-              <span aria-hidden="true">&laquo;</span>
-              <span class="sr-only">Previous</span>
-            </a>
+          <a aria-label="Previous" class="page-link" (click)="selectPage(page-1)">
+            <span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span>
+          </a>
         </li>
 
         <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page">
@@ -24,15 +31,30 @@ import {getValueInRange, toInteger} from '../util/util';
             <span class="sr-only">Next</span>
           </a>
         </li>
+        
+        <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext()">
+          <a aria-label="Last" class="page-link" (click)="selectPage(pages.length)">
+            <span aria-hidden="true">&raquo;&raquo;</span>
+            <span class="sr-only">Last</span>
+          </a>                
+        </li>        
       </ul>
     </nav>
   `
 })
 export class NgbPagination implements OnChanges {
+  private _boundaryLinks: boolean = false;
   private _collectionSize;
   private _page = 0;
   private _pageSize = 10;
   pages: number[] = [];
+
+  @Input()
+  set boundaryLinks(value: boolean) {
+    this._boundaryLinks = toBoolean(value);
+  }
+
+  get boundaryLinks(): boolean { return this._boundaryLinks; }
 
   @Input()
   set page(value: number | string) {


### PR DESCRIPTION
Adding "first/last" links to pagination

- disabled by default
- enabled via "boundaryLinks" attribute
- uses &laquo;&laquo; and &raquo;&raquo; as symbols

Plunker :http://plnkr.co/edit/UIeOOHCgfyxXIkS94ClD?p=preview

Closes #211