### PR TITLE
feat(pagination): ability to toggle previous/next links

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -183,10 +183,15 @@ describe('ngb-pagination', () => {
        })));
 
     it('should update selected page model on prev / next click', async(inject([TestComponentBuilder], (tcb) => {
-         const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="page"></ngb-pagination>';
+         const html =
+             '<ngb-pagination [collectionSize]="collectionSize" [page]="page" [directionLinks]="directionLinks"></ngb-pagination>';
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.collectionSize = 30;
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['+1', '2', '3']);
+
+           fixture.componentInstance.directionLinks = true;
            fixture.detectChanges();
            expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
@@ -248,4 +253,5 @@ class TestComponent {
   collectionSize = 100;
   page = 1;
   boundaryLinks = false;
+  directionLinks = false;
 }

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -14,7 +14,7 @@ import {getValueInRange, toInteger, toBoolean} from '../util/util';
           </a>                
         </li>
       
-        <li class="page-item" [class.disabled]="!hasPrevious()">
+        <li *ngIf="directionLinks"class="page-item" [class.disabled]="!hasPrevious()">
           <a aria-label="Previous" class="page-link" (click)="selectPage(page-1)">
             <span aria-hidden="true">&laquo;</span>
             <span class="sr-only">Previous</span>
@@ -25,7 +25,7 @@ import {getValueInRange, toInteger, toBoolean} from '../util/util';
           <a class="page-link" (click)="selectPage(pageNumber)">{{pageNumber}}</a>
         </li>
 
-        <li class="page-item" [class.disabled]="!hasNext()">
+        <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext()">
           <a aria-label="Next" class="page-link" (click)="selectPage(page+1)">
             <span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span>
@@ -45,6 +45,7 @@ import {getValueInRange, toInteger, toBoolean} from '../util/util';
 export class NgbPagination implements OnChanges {
   private _boundaryLinks: boolean = false;
   private _collectionSize;
+  private _directionLinks: boolean = true;
   private _page = 0;
   private _pageSize = 10;
   pages: number[] = [];
@@ -58,6 +59,16 @@ export class NgbPagination implements OnChanges {
   }
 
   get boundaryLinks(): boolean { return this._boundaryLinks; }
+
+  /**
+   *  Whether to show the "Next" and "Previous" page links
+   */
+  @Input()
+  set directionLinks(value: boolean) {
+    this._directionLinks = toBoolean(value);
+  }
+
+  get directionLinks(): boolean { return this._directionLinks; }
 
   /**
    *  Current page.


### PR DESCRIPTION
Pagination "previous"/"next" links are enabled by default, but can be hidden via "directionLinks" attribute

Plunker: http://plnkr.co/edit/UIeOOHCgfyxXIkS94ClD?p=preview

Closes #315