### PR TITLE
fix: add empty hrefs for styling

### DIFF
--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -24,7 +24,7 @@ let nextId = 0;
     <div class="panel panel-default" [class.panel-open]="open">
       <div class="panel-heading" role="tab" [id]="id">
         <h4 class="panel-title">
-          <a tabindex="0" (click)="toggleOpen($event)"><span [class.text-muted]="disabled">{{title}}</span></a>
+          <a tabindex="0" (click)="toggleOpen($event)" href><span [class.text-muted]="disabled">{{title}}</span></a>
         </h4>
       </div>
       <div class="panel-collapse" [ngbCollapse]="!open" [attr.aria-labelledby]="id" role="tabpanel">

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -49,11 +49,11 @@ export class NgbSlide {
         <template [ngTemplateOutlet]="slide.tplRef"></template>
       </div>
     </div>
-    <a class="left carousel-control" role="button" (click)="prev()">
+    <a class="left carousel-control" role="button" (click)="prev()" href>
       <span class="icon-prev" aria-hidden="true"></span>
       <span class="sr-only">Previous</span>
     </a>
-    <a class="right carousel-control" role="button" (click)="next()">
+    <a class="right carousel-control" role="button" (click)="next()" href>
       <span class="icon-next" aria-hidden="true"></span>
       <span class="sr-only">Next</span>
     </a>

--- a/src/pager/pager.ts
+++ b/src/pager/pager.ts
@@ -9,8 +9,8 @@ import {Component, ChangeDetectionStrategy, OnChanges, Input, Output, EventEmitt
   template: `
     <nav>
       <ul class="pager">
-        <li [class.disabled]="!hasPrev()" [class.pager-prev]="alignLinks"><a (click)="prev()">Previous</a></li>
-        <li [class.disabled]="!hasNext()" [class.pager-next]="alignLinks"><a (click)="next()">Next</a></li>
+        <li [class.disabled]="!hasPrev()" [class.pager-prev]="alignLinks"><a (click)="prev()" href>Previous</a></li>
+        <li [class.disabled]="!hasNext()" [class.pager-next]="alignLinks"><a (click)="next()" href>Next</a></li>
       </ul>
     </nav>
     `

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -11,32 +11,32 @@ import {getValueInRange, toInteger, toBoolean} from '../util/util';
     <nav>
       <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
         <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasPrevious()">
-          <a aria-label="First" class="page-link" (click)="selectPage(1)">
+          <a aria-label="First" class="page-link" (click)="selectPage(1)" href>
             <span aria-hidden="true">&laquo;&laquo;</span>
             <span class="sr-only">First</span>
           </a>                
         </li>
       
         <li *ngIf="directionLinks"class="page-item" [class.disabled]="!hasPrevious()">
-          <a aria-label="Previous" class="page-link" (click)="selectPage(page-1)">
+          <a aria-label="Previous" class="page-link" (click)="selectPage(page-1)" href>
             <span aria-hidden="true">&laquo;</span>
             <span class="sr-only">Previous</span>
           </a>
         </li>
 
         <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page">
-          <a class="page-link" (click)="selectPage(pageNumber)">{{pageNumber}}</a>
+          <a class="page-link" (click)="selectPage(pageNumber)" href>{{pageNumber}}</a>
         </li>
 
         <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext()">
-          <a aria-label="Next" class="page-link" (click)="selectPage(page+1)">
+          <a aria-label="Next" class="page-link" (click)="selectPage(page+1)" href>
             <span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span>
           </a>
         </li>
         
         <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext()">
-          <a aria-label="Last" class="page-link" (click)="selectPage(pages.length)">
+          <a aria-label="Last" class="page-link" (click)="selectPage(pages.length)" href>
             <span aria-hidden="true">&raquo;&raquo;</span>
             <span class="sr-only">Last</span>
           </a>                

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -58,7 +58,7 @@ export class NgbTab {
   template: `
     <ul [class]="'nav nav-' + type" role="tablist">
       <li class="nav-item" *ngFor="let tab of tabs">
-        <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled" (click)="select(tab.id)">
+        <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled" (click)="select(tab.id)" href>
           {{tab.title}}<template [ngTemplateOutlet]="tab.titleTpl?.templateRef"></template>
         </a>
       </li>


### PR DESCRIPTION
Just tested on the accordion example and it looks like empty `href`s are not causing any negative consequences and assure proper styling. We will have to keep an eye on this item, but let's try those empty `href`s.

Fixes #142 