### PR TITLE
docs(demo): fix side-nav

### DIFF
--- a/demo/src/app/shared/side-nav/side-nav.component.html
+++ b/demo/src/app/shared/side-nav/side-nav.component.html
@@ -19,9 +19,6 @@
           <li *ngFor="let component of components" [routerLinkActive]="['active']">
             <a [routerLink]="['/components', component.toLowerCase()]">{{ component }}</a>
           </li>
-          <li [routerLinkActive]="['active']">
-            <a [routerLink]="['/components/tooltip']">Tooltip</a>
-          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
Without this PR we've got duplicated `Tooltip` navigation link in side-nav. Probably a result of a bad merge.