### PR TITLE
chore: beef up demo generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "karma-jasmine": "^0.3.6",
     "karma-sourcemap-loader": "^0.3.6",
     "merge2": "^1.0.1",
+    "mkdirp": "^0.5.1",
     "node-sass": "^3.7.0",
     "postcss-loader": "^0.9.1",
     "prismjs": "^1.5.1",


### PR DESCRIPTION
This PR adds cmd args support to the demo generation script. With this change you can use it as `node misc/demo-gen.js [component] [demo1,demo2]` to generate demo skeletons. For example running ` node misc/demo-gen.js progressbar basic,striped` will give you skeleton for both basic and striped demos of the progressbar component.