### PR TITLE
feat(tabset): support tab 'change' event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {NgbDropdown, NgbDropdownToggle} from './dropdown/dropdown';
 export {NgbPagination} from './pagination/pagination';
 export {NgbProgressbar} from './progressbar/progressbar';
 export {NgbRating} from './rating/rating';
-export {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle} from './tabset/tabset';
+export {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle, NgbTabChangeEvent} from './tabset/tabset';
 export {NgbTooltip, NgbTooltipWindow, NGB_TOOLTIP_DIRECTIVES} from './tooltip/tooltip';
 export {NgbPopover, NgbPopoverWindow, NGB_POPOVER_DIRECTIVES} from './popover/popover';
 export {NgbRadioGroup, NgbRadioLabel, NgbRadio, NGB_RADIO_DIRECTIVES} from './buttons/radio';

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -6,7 +6,9 @@ import {
   Directive,
   TemplateRef,
   ContentChild,
-  AfterContentChecked
+  AfterContentChecked,
+  Output,
+  EventEmitter
 } from '@angular/core';
 
 let nextId = 0;
@@ -50,6 +52,15 @@ export class NgbTab {
 }
 
 /**
+ * The payload of the tab change event
+ */
+export interface NgbTabChangeEvent {
+  activeId: String;
+  nextId: String;
+  preventDefault();
+}
+
+/**
  * A component that makes it easy to create tabbed interface.
  */
 @Component({
@@ -83,10 +94,22 @@ export class NgbTabset implements AfterContentChecked {
    */
   @Input() type: string = 'tabs';
 
+  /**
+   * A tab change event fired right before the tab selection happens
+   */
+  @Output() change = new EventEmitter<NgbTabChangeEvent>();
+
   select(tabIdx: string) {
     let selectedTab = this._getTabById(tabIdx);
-    if (selectedTab && !selectedTab.disabled) {
-      this.activeId = selectedTab.id;
+    if (selectedTab && !selectedTab.disabled && this.activeId !== selectedTab.id) {
+      let defaultPrevented = false;
+
+      this.change.emit(
+          {activeId: this.activeId, nextId: selectedTab.id, preventDefault: () => { defaultPrevented = true; }});
+
+      if (!defaultPrevented) {
+        this.activeId = selectedTab.id;
+      }
     }
   }
 


### PR DESCRIPTION
Adds the 'change' output, that is fired right before tab selection. Payload contains current tab id, next tab id and preventDefault() function to cancel tab selection.

Closes #267