### PR TITLE
fix(pagination): right boundary link works with 'maxSize'

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -207,8 +207,8 @@ describe('ngb-pagination', () => {
        })));
 
     it('should update selected page model on first / last click', async(inject([TestComponentBuilder], (tcb) => {
-         const html =
-             '<ngb-pagination [collectionSize]="collectionSize" [page]="page" [boundaryLinks]="boundaryLinks"></ngb-pagination>';
+         const html = `<ngb-pagination [collectionSize]="collectionSize" [page]="page" [maxSize]="maxSize" 
+              [boundaryLinks]="boundaryLinks"></ngb-pagination>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.collectionSize = 30;
@@ -234,6 +234,22 @@ describe('ngb-pagination', () => {
            getLink(fixture.nativeElement, 0).click();
            fixture.detectChanges();
            expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+
+           // maxSize < number of pages
+           fixture.componentInstance.collectionSize = 70;
+           fixture.componentInstance.maxSize = 3;
+           fixture.detectChanges();
+           expectPages(
+               fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
+
+           getLink(fixture.nativeElement, 8).click();
+           fixture.detectChanges();
+           expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '-...', '+7', '-» Next', '-»» Last']);
+
+           getLink(fixture.nativeElement, 0).click();
+           fixture.detectChanges();
+           expectPages(
+               fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
          });
        })));
 

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -38,7 +38,7 @@ import {getValueInRange, toInteger, toBoolean} from '../util/util';
         </li>
         
         <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext()">
-          <a aria-label="Last" class="page-link" (click)="selectPage(pages.length)">
+          <a aria-label="Last" class="page-link" (click)="selectPage(_pageCount)">
             <span aria-hidden="true">&raquo;&raquo;</span>
             <span class="sr-only">Last</span>
           </a>                


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/core/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

The pagination 'Last' link was broken when 'maxSize' < total number of pages