### PR TITLE
fix(rating): star character instead of css classes

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -19,7 +19,7 @@ function getStar(compiled, num: number) {
   return getStars(compiled)[num - 1];
 }
 
-function getStars(element, selector = 'i') {
+function getStars(element, selector = 'span > span:not(.sr-only)') {
   return element.querySelectorAll(selector);
 }
 
@@ -27,7 +27,7 @@ function getState(compiled) {
   const stars = getStars(compiled);
   let state = [];
   for (let i = 0, l = stars.length; i < l; i++) {
-    state.push((stars[i].classList.contains('glyphicon-star') && !stars[i].classList.contains('glyphicon-star-empty')));
+    state.push((stars[i].textContent === String.fromCharCode(9733)));
   }
   return state;
 }

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -10,8 +10,8 @@ import {Component, ChangeDetectionStrategy, Input, Output, EventEmitter, OnInit}
     <span tabindex="0" (mouseleave)="reset()" aria-valuemin="0" [attr.aria-valuemax]="max" [attr.aria-valuenow]="rate">
       <template ngFor let-r [ngForOf]="range" let-index="index">
         <span class="sr-only">({{ index < rate ? '*' : ' ' }})</span>
-        <i class="glyphicon {{index < rate ? 'glyphicon-star' : 'glyphicon-star-empty'}}" (mouseenter)="enter(index + 1)"
-          (click)="update(index + 1)" [title]="r.title" [attr.aria-valuetext]="r.title"></i>
+        <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" [title]="r.title" 
+        [attr.aria-valuetext]="r.title">{{ index < rate ? '&#9733;' : '&#9734;' }}</span>
       </template>
     </span>
   `


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/core/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Suggestion: replace rating `glyphicon-star` classes by &#9733; and &#9734; symbols for #318 